### PR TITLE
Support displaying grepped CRs in summary tables

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ### Added
 
+- Improve tests coverage (@mbarbin).
 - New flag `crs grep --summary` to display information as summary tables (@mbarbin).
 
 ### Changed

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,17 @@
+## 0.0.2025XXXX (unreleased)
+
+### Added
+
+- New flag `crs grep --summary` to display information as summary tables (@mbarbin).
+
+### Changed
+
+### Deprecated
+
+### Fixed
+
+### Removed
+
 ## 0.0.20250414 (2025-04-14)
 
 This very early draft release is intended for publication to my custom opam-repository. It allows for initial experimentation and ensures that the release cycle and distribution process are functioning correctly.

--- a/lib/crs_cli/src/cmd__grep.ml
+++ b/lib/crs_cli/src/cmd__grep.ml
@@ -28,7 +28,28 @@ let main =
          (Param.validated_string (module Fpath))
          ~docv:"PATH"
          ~doc:"Only grep below the supplied path."
-     and sexp = Arg.flag [ "sexp" ] ~doc:"Print the CRs as sexps on stdout." in
+     and sexp = Arg.flag [ "sexp" ] ~doc:"Print the CRs as sexps on stdout."
+     and summary =
+       Arg.flag
+         [ "summary" ]
+         ~doc:
+           "This flags causes the command to print CR counts in summary tables rather \
+            than printing each CR individually. This is not compatible with $(b,sexp)."
+     in
+     let () =
+       if sexp && summary
+       then
+         Err.raise
+           ~exit_code:Err.Exit_code.cli_error
+           Pp.O.
+             [ Pp.text "The flags "
+               ++ Pp_tty.kwd (module String) "sexp"
+               ++ Pp.text " and "
+               ++ Pp_tty.kwd (module String) "summary"
+               ++ Pp.text " are exclusive."
+             ]
+           ~hints:[ Pp.text "Please choose one." ]
+     in
      let vcs = Vcs_git_blocking.create () in
      let cwd = Unix.getcwd () |> Absolute_path.v in
      let repo_root = Common_helpers.find_enclosing_repo_root vcs ~from:cwd in
@@ -42,5 +63,13 @@ let main =
      then
        List.iter crs ~f:(fun cr ->
          print_endline (Sexp.to_string_hum [%sexp (cr : Cr_comment.t)]))
+     else if summary
+     then (
+       let by_type = Summary_table.By_type.make crs |> Summary_table.By_type.to_string in
+       let summary = Summary_table.make crs |> Summary_table.to_string in
+       let tables =
+         List.filter [ by_type; summary ] ~f:(fun t -> not (String.is_empty t))
+       in
+       print_string (String.concat ~sep:"\n" tables))
      else Cr_comment.print_list ~crs)
 ;;

--- a/lib/crs_cli/src/cmd__grep.ml
+++ b/lib/crs_cli/src/cmd__grep.ml
@@ -48,7 +48,9 @@ let main =
                ++ Pp_tty.kwd (module String) "summary"
                ++ Pp.text " are exclusive."
              ]
-           ~hints:[ Pp.text "Please choose one." ]
+           ~hints:[ Pp.text "Please choose one." ] [@coverage off]
+       (* This is exercised in tests, however there is an issue regarding
+          out-edge of raising functions in bisect_ppx. TBD. *)
      in
      let vcs = Vcs_git_blocking.create () in
      let cwd = Unix.getcwd () |> Absolute_path.v in

--- a/lib/crs_cli/src/common_helpers.ml
+++ b/lib/crs_cli/src/common_helpers.ml
@@ -28,7 +28,7 @@ let find_enclosing_repo_root vcs ~from =
         [ Pp.text "Failed to locate enclosing repo root from '"
           ++ Pp_tty.path (module Absolute_path) from
           ++ Pp.text "'."
-        ]
+        ] [@coverage off]
 ;;
 
 let relativize ~repo_root ~cwd ~path =
@@ -43,5 +43,5 @@ let relativize ~repo_root ~cwd ~path =
         [ Pp.text "Path "
           ++ Pp_tty.path (module Absolute_path) path
           ++ Pp.text " is not in repo."
-        ]
+        ] [@coverage off]
 ;;

--- a/lib/crs_cli/src/summary_table.ml
+++ b/lib/crs_cli/src/summary_table.ml
@@ -1,0 +1,189 @@
+(********************************************************************************)
+(*  crs - A tool for managing code review comments embedded in source code      *)
+(*  Copyright (C) 2024-2025 Mathieu Barbin <mathieu.barbin@gmail.com>           *)
+(*                                                                              *)
+(*  This file is part of crs.                                                   *)
+(*                                                                              *)
+(*  crs is free software; you can redistribute it and/or modify it under the    *)
+(*  terms of the GNU Lesser General Public License as published by the Free     *)
+(*  Software Foundation either version 3 of the License, or any later version,  *)
+(*  with the LGPL-3.0 Linking Exception.                                        *)
+(*                                                                              *)
+(*  crs is distributed in the hope that it will be useful, but WITHOUT ANY      *)
+(*  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS   *)
+(*  FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License and     *)
+(*  the file `NOTICE.md` at the root of this repository for more details.       *)
+(*                                                                              *)
+(*  You should have received a copy of the GNU Lesser General Public License    *)
+(*  and the LGPL-3.0 Linking Exception along with this library. If not, see     *)
+(*  <http://www.gnu.org/licenses/> and <https://spdx.org>, respectively.        *)
+(********************************************************************************)
+
+module By_type = struct
+  module Type = struct
+    type t =
+      | Invalid
+      | CR
+      | XCR
+      | Soon
+      | Someday
+    [@@deriving compare, sexp_of]
+
+    let to_string t =
+      match sexp_of_t t with
+      | Atom a -> a
+      | List _ -> assert false
+    ;;
+
+    let of_cr (cr : Cr_comment.t) =
+      match Cr_comment.header cr with
+      | Error _ -> Invalid
+      | Ok h ->
+        (match Cr_comment.Header.kind h with
+         | XCR -> XCR
+         | CR ->
+           (match Cr_comment.Header.due h with
+            | Now -> CR
+            | Soon -> Soon
+            | Someday -> Someday))
+    ;;
+  end
+
+  module Row = struct
+    type t =
+      { type_ : Type.t
+      ; count : int
+      }
+  end
+
+  type t = { rows : Row.t list }
+
+  let make (crs : Cr_comment.t list) =
+    let rows =
+      List.map crs ~f:Type.of_cr
+      |> List.sort_and_group ~compare:Type.compare
+      |> List.map ~f:(function
+        | [] -> assert false
+        | type_ :: _ as list -> { Row.type_; count = List.length list })
+    in
+    { rows }
+  ;;
+
+  let columns =
+    Ascii_table.Column.
+      [ create_attr "type" (fun (row : Row.t) -> [], Type.to_string row.type_)
+      ; create_attr "count" ~align:Right (fun (row : Row.t) ->
+          ( (match row.type_ with
+             | Invalid -> [ `Red ]
+             | CR | XCR | Soon | Someday -> [])
+          , Int.to_string_hum row.count ))
+      ]
+  ;;
+
+  let to_string t =
+    if List.is_empty t.rows then "" else Ascii_table.to_string columns t.rows
+  ;;
+end
+
+module Type = struct
+  type t =
+    | CR
+    | XCR
+    | Soon
+    | Someday
+  [@@deriving equal]
+
+  let of_header h =
+    match Cr_comment.Header.kind h with
+    | XCR -> XCR
+    | CR ->
+      (match Cr_comment.Header.due h with
+       | Now -> CR
+       | Soon -> Soon
+       | Someday -> Someday)
+  ;;
+end
+
+module Key = struct
+  module T = struct
+    type t =
+      { reporter : Vcs.User_handle.t
+      ; for_ : Vcs.User_handle.t option
+      }
+    [@@deriving compare, sexp_of]
+  end
+
+  include T
+  include Comparable.Make (T)
+
+  let of_header (h : Cr_comment.Header.t) =
+    { reporter = Cr_comment.Header.reported_by h; for_ = Cr_comment.Header.for_ h }
+  ;;
+end
+
+module Row = struct
+  type t =
+    { reporter : Vcs.User_handle.t
+    ; for_ : Vcs.User_handle.t option
+    ; cr_count : int
+    ; xcr_count : int
+    ; soon_count : int
+    ; someday_count : int
+    ; total_count : int
+    }
+end
+
+type t = { rows : Row.t list }
+
+let make (crs : Cr_comment.t list) =
+  let rows =
+    List.filter_map crs ~f:(fun cr ->
+      match Cr_comment.header cr with
+      | Error _ -> None
+      | Ok h ->
+        let key = Key.of_header h in
+        let type_ = Type.of_header h in
+        Some (key, type_))
+    |> List.sort_and_group ~compare:(fun (k1, _) (k2, _) -> Key.compare k1 k2)
+    |> List.map ~f:(function
+      | [] -> assert false
+      | ({ Key.reporter; for_ }, _) :: _ as list ->
+        let count_type ty = List.count list ~f:(fun (_, type_) -> Type.equal type_ ty) in
+        { Row.reporter
+        ; for_
+        ; cr_count = count_type CR
+        ; xcr_count = count_type XCR
+        ; soon_count = count_type Soon
+        ; someday_count = count_type Someday
+        ; total_count = List.length list
+        })
+  in
+  { rows }
+;;
+
+let columns =
+  let empty_cell = [], "" in
+  let count_cell count = if count = 0 then empty_cell else [], Int.to_string_hum count in
+  Ascii_table.Column.
+    [ create_attr "reporter" (fun (row : Row.t) ->
+        [], Vcs.User_handle.to_string row.reporter)
+    ; create_attr "for" ~show:`If_not_empty (fun (row : Row.t) ->
+        match row.for_ with
+        | None -> empty_cell
+        | Some user -> [], Vcs.User_handle.to_string user)
+    ; create_attr "CRs" ~align:Right ~show:`If_not_empty (fun (row : Row.t) ->
+        count_cell row.cr_count)
+    ; create_attr "XCRs" ~align:Right ~show:`If_not_empty (fun (row : Row.t) ->
+        count_cell row.xcr_count)
+    ; create_attr "Soon" ~align:Right ~show:`If_not_empty (fun (row : Row.t) ->
+        count_cell row.soon_count)
+    ; create_attr "Someday" ~align:Right ~show:`If_not_empty (fun (row : Row.t) ->
+        count_cell row.someday_count)
+    ; create_attr "Total" ~align:Right ~show:`If_not_empty (fun (row : Row.t) ->
+        count_cell row.total_count)
+    ]
+;;
+
+let to_string t =
+  if List.is_empty t.rows then "" else Ascii_table.to_string columns t.rows
+;;

--- a/lib/crs_cli/src/summary_table.ml
+++ b/lib/crs_cli/src/summary_table.ml
@@ -105,16 +105,11 @@ module Type = struct
 end
 
 module Key = struct
-  module T = struct
-    type t =
-      { reporter : Vcs.User_handle.t
-      ; for_ : Vcs.User_handle.t option
-      }
-    [@@deriving compare, sexp_of]
-  end
-
-  include T
-  include Comparable.Make (T)
+  type t =
+    { reporter : Vcs.User_handle.t
+    ; for_ : Vcs.User_handle.t option
+    }
+  [@@deriving compare]
 
   let of_header (h : Cr_comment.Header.t) =
     { reporter = Cr_comment.Header.reported_by h; for_ = Cr_comment.Header.for_ h }

--- a/lib/crs_cli/src/summary_table.mli
+++ b/lib/crs_cli/src/summary_table.mli
@@ -1,0 +1,32 @@
+(*_*******************************************************************************)
+(*_  crs - A tool for managing code review comments embedded in source code      *)
+(*_  Copyright (C) 2024-2025 Mathieu Barbin <mathieu.barbin@gmail.com>           *)
+(*_                                                                              *)
+(*_  This file is part of crs.                                                   *)
+(*_                                                                              *)
+(*_  crs is free software; you can redistribute it and/or modify it under the    *)
+(*_  terms of the GNU Lesser General Public License as published by the Free     *)
+(*_  Software Foundation either version 3 of the License, or any later version,  *)
+(*_  with the LGPL-3.0 Linking Exception.                                        *)
+(*_                                                                              *)
+(*_  crs is distributed in the hope that it will be useful, but WITHOUT ANY      *)
+(*_  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS   *)
+(*_  FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License and     *)
+(*_  the file `NOTICE.md` at the root of this repository for more details.       *)
+(*_                                                                              *)
+(*_  You should have received a copy of the GNU Lesser General Public License    *)
+(*_  and the LGPL-3.0 Linking Exception along with this library. If not, see     *)
+(*_  <http://www.gnu.org/licenses/> and <https://spdx.org>, respectively.        *)
+(*_*******************************************************************************)
+
+module By_type : sig
+  type t
+
+  val make : Cr_comment.t list -> t
+  val to_string : t -> string
+end
+
+type t
+
+val make : Cr_comment.t list -> t
+val to_string : t -> string

--- a/lib/crs_parser/src/crs_parser.ml
+++ b/lib/crs_parser/src/crs_parser.ml
@@ -79,7 +79,7 @@ let grep ~vcs ~repo_root ~below =
     let exit_code, stdout = Shexp_process.eval ~context process in
     match exit_code with
     | 0 | 123 -> stdout |> String.split_lines |> List.map ~f:Vcs.Path_in_repo.v
-    | _ -> raise_s [%sexp "xargs process failed", { exit_code : int }]
+    | _ -> raise_s [%sexp "xargs process failed", { exit_code : int }] [@coverage off]
   in
   List.concat_map files_to_grep ~f:(fun path_in_repo ->
     let file_contents =

--- a/test/cram/grep.t
+++ b/test/cram/grep.t
@@ -41,6 +41,8 @@ If we grep from there, there is no CR in the tree.
 
   $ crs grep --sexp
 
+  $ crs grep --summary
+
 Now let's add some CRs.
 
   $ echo -e "(* $CR user1: Hey, this is a code review comment *)" >> hello
@@ -101,3 +103,10 @@ There's also an option to display the results as summary tables.
   ├──────────┼─────┼──────┼──────┼───────┤
   │ user1    │   1 │    1 │    1 │     3 │
   └──────────┴─────┴──────┴──────┴───────┘
+
+Summary tables may not be displayed as sexps.
+
+  $ crs grep --summary --sexp
+  Error: The flags [sexp] and [summary] are exclusive.
+  Hint: Please choose one.
+  [124]

--- a/test/cram/grep.t
+++ b/test/cram/grep.t
@@ -67,21 +67,37 @@ A basic [sexp] output is available.
    (digest_of_condensed_content 1c65b0067541949bf40979567396b403)
    (content "CR user1: Hey, this is a code review comment "))
 
-The default is to print them, visually separated. Here we tweak the output to
-avoid risking having actual CRs in this file.
+The default is to print them, visually separated.
 
-  $ crs grep | sed -e 's/ CR/ $CR/g' -e 's/ XCR/ $XCR/g'
+  $ crs grep
   File "foo/a.txt", line 2, characters 3-41:
-    $XCR user1: Fix this. Edit: Done. 
+    XCR user1: Fix this. Edit: Done. 
   
   File "foo/bar/b.txt", line 2, characters 3-58:
-    $CR-soon user1: Hey, this is a code review comment 
+    CR-soon user1: Hey, this is a code review comment 
   
   File "hello", line 2, characters 3-53:
-    $CR user1: Hey, this is a code review comment 
+    CR user1: Hey, this is a code review comment 
 
 You may restrict the search to a subdirectory only.
 
   $ crs grep --below ./foo/bar
   File "foo/bar/b.txt", line 2, characters 3-58:
     CR-soon user1: Hey, this is a code review comment 
+
+There's also an option to display the results as summary tables.
+
+  $ crs grep --summary
+  ┌──────┬───────┐
+  │ type │ count │
+  ├──────┼───────┤
+  │ CR   │     1 │
+  │ XCR  │     1 │
+  │ Soon │     1 │
+  └──────┴───────┘
+  
+  ┌──────────┬─────┬──────┬──────┬───────┐
+  │ reporter │ CRs │ XCRs │ Soon │ Total │
+  ├──────────┼─────┼──────┼──────┼───────┤
+  │ user1    │   1 │    1 │    1 │     3 │
+  └──────────┴─────┴──────┴──────┴───────┘

--- a/test/expect/test__crs_rewriter.ml
+++ b/test/expect/test__crs_rewriter.ml
@@ -173,6 +173,11 @@ let () =
   ()
 ;;
 
+let () =
+  (* $CR user1 for user2: Message *)
+  ()
+;;
+
 (* $XCR jdoe: This other message *)
 let () = ()
 
@@ -192,11 +197,16 @@ let () = ()
             ~text:" for assignee")));
   [%expect
     {|
-    -1,11 +1,11
+    -1,16 +1,16
 
       let () =
     -|  (* $CR user1: Message *)
     +|  (* $CR user1 for assignee: Message *)
+        ()
+      ;;
+
+      let () =
+        (* $CR user1 for user2: Message *)
         ()
       ;;
 
@@ -206,7 +216,8 @@ let () = ()
 
     -|(* $CR user1: This third message *)
     +|(* $CR user1 for assignee: This third message *)
-      let () = () |}];
+      let () = ()
+    |}];
   ()
 ;;
 


### PR DESCRIPTION
### Added

- Improve tests coverage.
- New flag `crs grep --summary` to display information as summary tables.
