### PR TITLE
Grep show sexp locations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 ### Changed
 
+- Include locations in the output of `crs grep --sexp` (#24, @mbarbin).
 - Reduce dependencies and replace `re2` by `ocaml-re` (#17, @mbarbin).
 - Reduce dependencies and replace `shexp` by `spawn` (#16, @mbarbin).
 - Make `crs grep` output in a pager when able (#16, @mbarbin).
@@ -14,6 +15,7 @@
 
 ### Fixed
 
+- Fix position mismatch in tests shown by `ocaml-ci` (#23, @mbarbin).
 - Disable failing build with 5.4 alpha release (#19, @mbarbin).
 - Adapt grep implementation for portability to MacOS (#19, @mbarbin).
 

--- a/lib/crs_cli/src/cmd__grep.ml
+++ b/lib/crs_cli/src/cmd__grep.ml
@@ -67,8 +67,9 @@ let main =
        let oc = Git_pager.write_end git_pager in
        if sexp
        then
-         List.iter crs ~f:(fun cr ->
-           Out_channel.output_line oc (Sexp.to_string_hum [%sexp (cr : Cr_comment.t)]))
+         Ref.set_temporarily Loc.include_sexp_of_locs true ~f:(fun () ->
+           List.iter crs ~f:(fun cr ->
+             Out_channel.output_line oc (Sexp.to_string_hum [%sexp (cr : Cr_comment.t)])))
        else if summary
        then (
          let by_type =

--- a/test/cram/grep.t
+++ b/test/cram/grep.t
@@ -75,38 +75,74 @@ Now let's grep for the CRs.
 A basic [sexp] output is available.
 
   $ crs grep --sexp
-  ((path foo/a.txt) (whole_loc _)
-   (header (Ok ((kind XCR) (due Now) (reported_by user1) (for_ ()))))
+  ((path foo/a.txt) (whole_loc ((start foo/a.txt:2:0) (stop foo/a.txt:2:38)))
+   (header
+    (Ok
+     ((kind ((txt XCR) (loc ((start foo/a.txt:2:3) (stop foo/a.txt:2:6)))))
+      (due ((txt Now) (loc ((start foo/a.txt:2:3) (stop foo/a.txt:2:6)))))
+      (reported_by
+       ((txt user1) (loc ((start foo/a.txt:2:7) (stop foo/a.txt:2:12)))))
+      (for_ ()))))
    (digest_of_condensed_content 9dce8eceb787a95abf3fccb037d164ea)
    (content "XCR user1: Fix this. Edit: Done."))
-  ((path foo/b.txt) (whole_loc _)
-   (header (Ok ((kind CR) (due Someday) (reported_by user1) (for_ ()))))
+  ((path foo/b.txt) (whole_loc ((start foo/b.txt:1:0) (stop foo/b.txt:1:71)))
+   (header
+    (Ok
+     ((kind ((txt CR) (loc ((start foo/b.txt:1:3) (stop foo/b.txt:1:5)))))
+      (due ((txt Someday) (loc ((start foo/b.txt:1:6) (stop foo/b.txt:1:13)))))
+      (reported_by
+       ((txt user1) (loc ((start foo/b.txt:1:14) (stop foo/b.txt:1:19)))))
+      (for_ ()))))
    (digest_of_condensed_content 22722b7a3948f75ec004a651d97d02bb)
    (content
     "CR-someday user1: Reconsider if/when updating to the new version."))
-  ((path foo/bar/b.txt) (whole_loc _)
-   (header (Ok ((kind CR) (due Soon) (reported_by user1) (for_ ()))))
+  ((path foo/bar/b.txt)
+   (whole_loc ((start foo/bar/b.txt:2:0) (stop foo/bar/b.txt:2:55)))
+   (header
+    (Ok
+     ((kind
+       ((txt CR) (loc ((start foo/bar/b.txt:2:3) (stop foo/bar/b.txt:2:5)))))
+      (due
+       ((txt Soon) (loc ((start foo/bar/b.txt:2:6) (stop foo/bar/b.txt:2:10)))))
+      (reported_by
+       ((txt user1)
+        (loc ((start foo/bar/b.txt:2:11) (stop foo/bar/b.txt:2:16)))))
+      (for_ ()))))
    (digest_of_condensed_content 8b683d9bff5df08ee3642df3cf2426ce)
    (content "CR-soon user1: Hey, this is a code review comment"))
-  ((path foo/bar/c.txt) (whole_loc _)
+  ((path foo/bar/c.txt)
+   (whole_loc ((start foo/bar/c.txt:1:0) (stop foo/bar/c.txt:1:52)))
    (header
     (Error
      ("Invalid CR comment" "CR-user: Hey, I'm trying to use CR, it's cool!")))
    (digest_of_condensed_content 49a84095611ebd8cb3f83e4546e67533)
    (content "CR-user: Hey, I'm trying to use CR, it's cool!"))
-  ((path foo/bar/d.txt) (whole_loc _)
+  ((path foo/bar/d.txt)
+   (whole_loc ((start foo/bar/d.txt:1:0) (stop foo/bar/d.txt:1:67)))
    (header
     (Error
      ("Invalid CR comment"
       "CR : Hey, this comment look like a CR but it's not quite one.")))
    (digest_of_condensed_content d8a25b0acac6d3a23ff4f4c1e4c990a3)
    (content "CR : Hey, this comment look like a CR but it's not quite one."))
-  ((path foo/foo.c) (whole_loc _)
-   (header (Ok ((kind CR) (due Now) (reported_by user1) (for_ (user3)))))
+  ((path foo/foo.c) (whole_loc ((start foo/foo.c:1:0) (stop foo/foo.c:1:60)))
+   (header
+    (Ok
+     ((kind ((txt CR) (loc ((start foo/foo.c:1:3) (stop foo/foo.c:1:5)))))
+      (due ((txt Now) (loc ((start foo/foo.c:1:3) (stop foo/foo.c:1:5)))))
+      (reported_by
+       ((txt user1) (loc ((start foo/foo.c:1:6) (stop foo/foo.c:1:11)))))
+      (for_
+       (((txt user3) (loc ((start foo/foo.c:1:16) (stop foo/foo.c:1:21)))))))))
    (digest_of_condensed_content 4721a5c5f8a37bdcb9e065268bbd0153)
    (content "CR user1 for user3: Hey, this is a code review comment"))
-  ((path hello) (whole_loc _)
-   (header (Ok ((kind CR) (due Now) (reported_by user1) (for_ (user2)))))
+  ((path hello) (whole_loc ((start hello:2:0) (stop hello:2:60)))
+   (header
+    (Ok
+     ((kind ((txt CR) (loc ((start hello:2:3) (stop hello:2:5)))))
+      (due ((txt Now) (loc ((start hello:2:3) (stop hello:2:5)))))
+      (reported_by ((txt user1) (loc ((start hello:2:6) (stop hello:2:11)))))
+      (for_ (((txt user2) (loc ((start hello:2:16) (stop hello:2:21)))))))))
    (digest_of_condensed_content 970aabfe0c3d4ec5707918edd3f01a8a)
    (content "CR user1 for user2: Hey, this is a code review comment"))
 


### PR DESCRIPTION
Include locations in the output of `crs grep --sexp`.