### PR TITLE
Add cwd emacs header

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,8 @@
-## 0.0.2025XXXX (unreleased)
+## 0.0.20250704 (2025-07-04)
 
 ### Added
 
+- Display the repo-root in the emacs-mode header (#47, @mbarbin).
 - Add 's' for summary tables in emacs crs-grep-mode (#45, @mbarbin).
 
 ### Changed

--- a/editor-integration/emacs/crs-grep.el
+++ b/editor-integration/emacs/crs-grep.el
@@ -166,9 +166,10 @@ Always a string, e.g. \"now\", \"all\", etc.")
                 (crs-grep-mode)
                 (when crs-grep-enable-header-line
                   (setq header-line-format
-                        (format "CRs: type \"%s\"   path \"%s\""
+                        (format "CRs: type \"%s\"   path \"%s\"   repo \"%s\""
                                 crs-grep-current-filter
-                                crs-grep-path-in-repo)))
+                                crs-grep-path-in-repo
+                                crs-grep-repo-root)))
                 (when crs-grep-enable-next-error-follow
                   (next-error-follow-minor-mode 1))
                 (goto-char (point-min)))


### PR DESCRIPTION
- Display the repo-root in the emacs-mode header

For example:

`CRs: type "now"  path "./path/in/repo"  repo "/path/to/repo"`