### PR TITLE
Refactor crs workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,27 +41,6 @@ jobs:
       - name: Build
         run: opam exec -- dune build @all @lint
 
-      - name: Install reviewdog
-        uses: reviewdog/action-setup@v1
-
-      # Here we can have a few CRs workflow that should permit to test the crs
-      # built from that PR and its interaction with other tools like reviewdog,
-      # GitHub annotations, step summaries, etc.
-
-      - name: Annotate CRs with reviewdog
-        if: github.event_name == 'pull_request'
-        run: |
-          opam exec -- dune exec crs -- tools reviewdog annotate-crs \
-            --config=.github/crs-config.json \
-            --review-mode=pull-request \
-            --pull-request-author="${{ github.event.pull_request.user.login }}" \
-          | reviewdog -f=rdjson -name="crs" -reporter=github-pr-review
-        env:
-          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Add CRs summary to workflow run summary
-        run: opam exec -- dune exec crs -- tools github summary-comment >> $GITHUB_STEP_SUMMARY
-
       - name: Run tests
         run: |
           mkdir $BISECT_DIR

--- a/.github/workflows/crs.yml
+++ b/.github/workflows/crs.yml
@@ -30,6 +30,11 @@ jobs:
         run: |
           dune pkg lock
 
+      - name: Build 'crs'
+        shell: bash
+        run: |
+          dune exec crs -- --version
+
       - name: Install reviewdog
         uses: reviewdog/action-setup@v1
 

--- a/.github/workflows/crs.yml
+++ b/.github/workflows/crs.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install reviewdog
         uses: reviewdog/action-setup@v1
 
-      # Here we can have a few CRs workflow that should permit to test the crs
+      # Here we can have a few CRs workflows that should permit to test the crs
       # built from that PR and its interaction with other tools like reviewdog,
       # GitHub annotations, step summaries, etc.
 

--- a/.github/workflows/crs.yml
+++ b/.github/workflows/crs.yml
@@ -1,0 +1,52 @@
+name: CRs Workflows
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - "**" # This will match pull requests targeting any branch
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        runs-on: [ubuntu-latest]
+    runs-on: ${{ matrix.runs-on }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup dune
+        id: setup-dune
+        uses: ocaml-dune/setup-dune@v0.0.1
+        with:
+          automagic: false
+
+      - name: Resolve dependencies
+        shell: bash
+        run: |
+          dune pkg lock
+
+      - name: Install reviewdog
+        uses: reviewdog/action-setup@v1
+
+      # Here we can have a few CRs workflow that should permit to test the crs
+      # built from that PR and its interaction with other tools like reviewdog,
+      # GitHub annotations, step summaries, etc.
+
+      - name: Annotate CRs with reviewdog
+        if: github.event_name == 'pull_request'
+        run: |
+          dune exec crs -- tools reviewdog annotate-crs \
+            --config=.github/crs-config.json \
+            --review-mode=pull-request \
+            --pull-request-author="${{ github.event.pull_request.user.login }}" \
+          | reviewdog -f=rdjson -name="crs" -reporter=github-pr-review
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Add CRs summary to workflow run summary
+        run: dune exec crs -- tools github summary-comment >> $GITHUB_STEP_SUMMARY

--- a/lib/crs_cli/src/cmd__tools__github__summary_comment.ml
+++ b/lib/crs_cli/src/cmd__tools__github__summary_comment.ml
@@ -80,5 +80,7 @@ This command is meant to be used to generate contents to include to the history 
               "Users with assigned CRs/XCRs: %s"
               (String.concat ~sep:", " assignees))
      in
+     (* CR mbarbin: Remove after testing this. *)
+     print_endline "Hello crs built from this PR!";
      ())
 ;;

--- a/lib/crs_cli/src/cmd__tools__github__summary_comment.ml
+++ b/lib/crs_cli/src/cmd__tools__github__summary_comment.ml
@@ -80,7 +80,5 @@ This command is meant to be used to generate contents to include to the history 
               "Users with assigned CRs/XCRs: %s"
               (String.concat ~sep:", " assignees))
      in
-     (* CR mbarbin: Remove after testing this. *)
-     print_endline "Hello crs built from this PR!";
      ())
 ;;


### PR DESCRIPTION
Separate CRs Workflows from the main CI jobs.

Use setup-dune in the crs workflows in an attempt to make use of the dune built-in cache. That part is WIP.