### PR TITLE
Add getters for offsets and prefix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 ## 0.0.2025XXXX (unreleased)
 
+### Added
+
+- Add getters for cr comment content start offset and prefix (#61, @mbarbin).
+
 ### Changed
 
 - Wrap CLI readme text using code margin (#60, @mbarbin).

--- a/lib/cr_comment/src/cr_comment0.ml
+++ b/lib/cr_comment/src/cr_comment0.ml
@@ -135,6 +135,7 @@ module T = struct
   type t =
     { path : Vcs.Path_in_repo.t
     ; whole_loc : Loc.t
+    ; content_start_offset : int
     ; header : Header.t Or_error.t
     ; comment_prefix : string
     ; digest_of_condensed_content : Digest_hex.t
@@ -147,11 +148,28 @@ include T
 
 let path t = t.path
 let content t = t.content
+let content_start_offset t = t.content_start_offset
+let comment_prefix t = t.comment_prefix
 let whole_loc t = t.whole_loc
 let header t = t.header
 
-let create ~path ~whole_loc ~header ~comment_prefix ~digest_of_condensed_content ~content =
-  { path; whole_loc; header; comment_prefix; digest_of_condensed_content; content }
+let create
+      ~path
+      ~whole_loc
+      ~content_start_offset
+      ~header
+      ~comment_prefix
+      ~digest_of_condensed_content
+      ~content
+  =
+  { path
+  ; whole_loc
+  ; content_start_offset
+  ; header
+  ; comment_prefix
+  ; digest_of_condensed_content
+  ; content
+  }
 ;;
 
 let digest_ignoring_minor_text_changes t = t.digest_of_condensed_content

--- a/lib/cr_comment/src/cr_comment0.mli
+++ b/lib/cr_comment/src/cr_comment0.mli
@@ -180,6 +180,16 @@ val path : t -> Vcs.Path_in_repo.t
     beginning and end (if applicable). See also {!reindented_content}. *)
 val content : t -> string
 
+(** This is the offset in the original file at which the [content] field
+    started. This is useful if you need to reparse the content of CRs
+    dynamically while being able to build locations. *)
+val content_start_offset : t -> int
+
+(** This is the leading string that contains the comment markers on the left of
+    the [content] field, stripped. This may be useful when linting comments and
+    working on CR formatting. *)
+val comment_prefix : t -> string
+
 (** [whole_loc] is suitable for removal of the entire CR comment. It includes
     the comments boundaries from [path] as well. *)
 val whole_loc : t -> Loc.t
@@ -251,6 +261,7 @@ module Private : sig
   val create
     :  path:Vcs.Path_in_repo.t
     -> whole_loc:Loc.t
+    -> content_start_offset:int
     -> header:header Or_error.t
     -> comment_prefix:string
     -> digest_of_condensed_content:Digest_hex.t

--- a/lib/crs_cli/test/test__annotation.ml
+++ b/lib/crs_cli/test/test__annotation.ml
@@ -43,8 +43,9 @@ let%expect_test "sexp_of_t" =
     {|
     ((
       (cr (
-        (path      my_file.ml)
-        (whole_loc _)
+        (path                 my_file.ml)
+        (whole_loc            _)
+        (content_start_offset 3)
         (header (
           Ok (
             (status    CR)

--- a/test/cram/grep.t
+++ b/test/cram/grep.t
@@ -91,6 +91,7 @@ A basic [sexp] output is available.
 
   $ crs grep --sexp
   ((path foo/a.txt) (whole_loc ((start foo/a.txt:2:0) (stop foo/a.txt:2:38)))
+   (content_start_offset 31)
    (header
     (Ok
      ((status ((txt XCR) (loc ((start foo/a.txt:2:3) (stop foo/a.txt:2:6)))))
@@ -103,6 +104,7 @@ A basic [sexp] output is available.
    (digest_of_condensed_content 9dce8eceb787a95abf3fccb037d164ea)
    (content "XCR user1: Fix this. Edit: Done."))
   ((path foo/b.txt) (whole_loc ((start foo/b.txt:1:0) (stop foo/b.txt:1:71)))
+   (content_start_offset 3)
    (header
     (Ok
      ((status ((txt CR) (loc ((start foo/b.txt:1:3) (stop foo/b.txt:1:5)))))
@@ -117,6 +119,7 @@ A basic [sexp] output is available.
     "CR-someday user1: Reconsider if/when updating to the new version."))
   ((path foo/bar/b.txt)
    (whole_loc ((start foo/bar/b.txt:2:0) (stop foo/bar/b.txt:2:55)))
+   (content_start_offset 35)
    (header
     (Ok
      ((status
@@ -132,6 +135,7 @@ A basic [sexp] output is available.
    (content "CR-soon user1: Hey, this is a code review comment"))
   ((path foo/bar/c.txt)
    (whole_loc ((start foo/bar/c.txt:1:0) (stop foo/bar/c.txt:1:52)))
+   (content_start_offset 3)
    (header
     (Error
      ("Invalid CR comment" "CR-user: Hey, I'm trying to use CR, it's cool!")))
@@ -140,6 +144,7 @@ A basic [sexp] output is available.
    (content "CR-user: Hey, I'm trying to use CR, it's cool!"))
   ((path foo/bar/d.txt)
    (whole_loc ((start foo/bar/d.txt:1:0) (stop foo/bar/d.txt:1:67)))
+   (content_start_offset 3)
    (header
     (Error
      ("Invalid CR comment"
@@ -148,6 +153,7 @@ A basic [sexp] output is available.
    (digest_of_condensed_content d8a25b0acac6d3a23ff4f4c1e4c990a3)
    (content "CR : Hey, this comment look like a CR but it's not quite one."))
   ((path foo/foo.c) (whole_loc ((start foo/foo.c:1:0) (stop foo/foo.c:1:60)))
+   (content_start_offset 3)
    (header
     (Ok
      ((status ((txt CR) (loc ((start foo/foo.c:1:3) (stop foo/foo.c:1:5)))))
@@ -161,6 +167,7 @@ A basic [sexp] output is available.
    (digest_of_condensed_content 4721a5c5f8a37bdcb9e065268bbd0153)
    (content "CR user1 for user3: Hey, this is a code review comment"))
   ((path hello) (whole_loc ((start hello:2:0) (stop hello:2:60)))
+   (content_start_offset 15)
    (header
     (Ok
      ((status ((txt CR) (loc ((start hello:2:3) (stop hello:2:5)))))


### PR DESCRIPTION
These values may be useful when working on dynamically parsing, linting and or reformatting CRs.