### PR TITLE
Ignore not a crs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,11 +2,13 @@
 
 ### Added
 
+- Add invalid CRs parser (#65, @mbarbin).
 - Add getters for cr comment content start offset and prefix (#63, @mbarbin).
 - Add more tests for invalid CRs (#61, #64, @mbarbin).
 
 ### Changed
 
+- Ignore CRs that are considered not-a-cr by the invalid CRs parser (#66, @mbarbin).
 - Install crs in the CI actions PATH and use shared crs actions (#62, @mbarbin).
 - Wrap CLI readme text using code margin (#60, @mbarbin).
 - Switch from `text-table` to upstream `print-table` lib (#59, @mbarbin).

--- a/lib/crs_parser/test/test__crs_parser.ml
+++ b/lib/crs_parser/test/test__crs_parser.ml
@@ -100,127 +100,27 @@ let%expect_test "invalid syntax CR" =
     {|
 (* $CR *)
 |};
-  [%expect
-    {|
-    ========================
-    CR
-    ((raw (
-       (path my_file.ml)
-       (whole_loc (
-         (start my_file.ml:1:0)
-         (stop  my_file.ml:2:0)))
-       (content_start_offset 3)
-       (header (Error ("Invalid CR comment" CR)))
-       (comment_prefix "(*")
-       (digest_of_condensed_content 1d7b33fc26ca22c2011aaa97fecc43d8)
-       (content CR)))
-     (getters (
-       (path    my_file.ml)
-       (content CR)
-       (status  CR)
-       (qualifier ())
-       (priority Now))))
-    |}];
+  [%expect {||}];
   test
     {|
 (* $CR : *)
 |};
-  [%expect
-    {|
-    ========================
-    CR :
-    ((raw (
-       (path my_file.ml)
-       (whole_loc (
-         (start my_file.ml:1:0)
-         (stop  my_file.ml:2:0)))
-       (content_start_offset 3)
-       (header (Error ("Invalid CR comment" "CR :")))
-       (comment_prefix "(*")
-       (digest_of_condensed_content 4ecc072f951465fb458ef1c75ffc6e24)
-       (content "CR :")))
-     (getters (
-       (path    my_file.ml)
-       (content "CR :")
-       (status  CR)
-       (qualifier ())
-       (priority Now))))
-    |}];
+  [%expect {||}];
   test
     {|
 (* $CR-user *)
 |};
-  [%expect
-    {|
-    ========================
-    CR-user
-    ((raw (
-       (path my_file.ml)
-       (whole_loc (
-         (start my_file.ml:1:0)
-         (stop  my_file.ml:2:0)))
-       (content_start_offset 3)
-       (header (Error ("Invalid CR comment" CR-user)))
-       (comment_prefix "(*")
-       (digest_of_condensed_content b1e92145e4e45e8538a73aece031a01d)
-       (content CR-user)))
-     (getters (
-       (path    my_file.ml)
-       (content CR-user)
-       (status  CR)
-       (qualifier ())
-       (priority Now))))
-    |}];
+  [%expect {||}];
   test
     {|
 (* $CR-user: *)
 |};
-  [%expect
-    {|
-    ========================
-    CR-user:
-    ((raw (
-       (path my_file.ml)
-       (whole_loc (
-         (start my_file.ml:1:0)
-         (stop  my_file.ml:2:0)))
-       (content_start_offset 3)
-       (header (Error ("Invalid CR comment" CR-user:)))
-       (comment_prefix "(*")
-       (digest_of_condensed_content 17497801764b8cc56107b683d2c30d55)
-       (content CR-user:)))
-     (getters (
-       (path    my_file.ml)
-       (content CR-user:)
-       (status  CR)
-       (qualifier ())
-       (priority Now))))
-    |}];
+  [%expect {||}];
   test
     {|
 (* $CR user *)
 |};
-  [%expect
-    {|
-    ========================
-    CR user
-    ((raw (
-       (path my_file.ml)
-       (whole_loc (
-         (start my_file.ml:1:0)
-         (stop  my_file.ml:2:0)))
-       (content_start_offset 3)
-       (header (Error ("Invalid CR comment" "CR user")))
-       (comment_prefix "(*")
-       (digest_of_condensed_content d0469bb593e8d5de0103ff72946e8013)
-       (content "CR user")))
-     (getters (
-       (path    my_file.ml)
-       (content "CR user")
-       (status  CR)
-       (qualifier ())
-       (priority Now))))
-    |}];
+  [%expect {||}];
   (* With text. *)
   test
     {|

--- a/lib/crs_parser/test/test__invalid_crs.ml
+++ b/lib/crs_parser/test/test__invalid_crs.ml
@@ -74,7 +74,7 @@ let test file_contents =
              ~content_start_offset:(Cr_comment.content_start_offset cr)
              ~content:(Cr_comment.content cr)
          with
-         | Not_a_cr -> None
+         | Not_a_cr -> assert false
          | Invalid_cr cr -> Some cr))
   in
   Ref.set_temporarily Loc.include_sexp_of_locs false ~f:(fun () ->

--- a/test/expect/test__lint_invalid_crs.ml
+++ b/test/expect/test__lint_invalid_crs.ml
@@ -47,7 +47,7 @@ let test file_contents ~f =
              ~content_start_offset:(Cr_comment.content_start_offset cr)
              ~content:(Cr_comment.content cr)
          with
-         | Not_a_cr -> ()
+         | Not_a_cr -> assert false
          | Invalid_cr cr -> f cr ~file_rewriter)))
 ;;
 


### PR DESCRIPTION
Ignore CRs that are considered not-a-cr by the invalid CRs parser.

This results in removing false positives, and a less noisy CR user experience overall.