### PR TITLE
Improve crs config

### DIFF
--- a/lib/crs_cli/src/annotation.ml
+++ b/lib/crs_cli/src/annotation.ml
@@ -71,8 +71,9 @@ let of_cr ~cr ~(config : Config.t) ~review_mode ~with_user_mentions =
     let header = Cr_comment.header cr in
     let severity : Severity.t =
       match header with
-      | Error _ -> Option.value config.invalid_crs_annotation_severity ~default:Warning
-      | Ok _ -> Option.value config.crs_due_now_annotation_severity ~default:Info
+      | Error _ ->
+        Option.value (Config.invalid_crs_annotation_severity config) ~default:Warning
+      | Ok _ -> Option.value (Config.crs_due_now_annotation_severity config) ~default:Info
     in
     let title =
       match header with
@@ -87,7 +88,7 @@ let of_cr ~cr ~(config : Config.t) ~review_mode ~with_user_mentions =
         (match assignee.user with
          | None -> false
          | Some user ->
-           (match config.user_mentions_whitelist with
+           (match Config.user_mentions_allowlist config with
             | None -> false
             | Some list -> List.mem list user ~equal:Vcs.User_handle.equal))
     in

--- a/lib/crs_cli/src/assignee.ml
+++ b/lib/crs_cli/src/assignee.ml
@@ -79,7 +79,7 @@ let of_raw
     | Pull_request { author; base = _ } ->
       { user = Some author; reason = Pull_request_author }
     | Revision ->
-      (match config.default_repo_owner with
+      (match Config.default_repo_owner config with
        | Some owner -> { user = Some owner; reason = Default_repo_owner }
        | None -> { user = None; reason = No_default_repo_owner })
   in

--- a/lib/crs_cli/src/cmd__tools__config__validate.ml
+++ b/lib/crs_cli/src/cmd__tools__config__validate.ml
@@ -27,9 +27,16 @@ let main =
        file for $(b,crs).")
     (let open Command.Std in
      let+ path = Arg.pos ~pos:0 Param.file ~doc:"Config file to customize crs."
-     and+ print =
-       Arg.flag [ "print" ] ~doc:"Print the parsed config as a S-expression."
+     and+ print = Arg.flag [ "print" ] ~doc:"Print the parsed config as a S-expression."
+     and+ print_gh_annotation_warnings =
+       Arg.named_with_default
+         [ "with-github-annotations-warnings" ]
+         Param.bool
+         ~default:false
+         ~doc:
+           "Optionally print GitHub Annotations Warnings to highlight deprecated \
+            constructs, in addition to regular warning printed to stderr."
      in
-     let config = Config.load_exn ~path:(Fpath.v path) in
+     let config = Config.load_exn ~path:(Fpath.v path) ~print_gh_annotation_warnings in
      if print then print_s [%sexp (config : Config.t)])
 ;;

--- a/lib/crs_cli/src/cmd__tools__github__annotate_crs.ml
+++ b/lib/crs_cli/src/cmd__tools__github__annotate_crs.ml
@@ -36,7 +36,8 @@ let main =
      let config =
        match config with
        | None -> Config.empty
-       | Some path -> Config.load_exn ~path:(Fpath.v path)
+       | Some path ->
+         Config.load_exn ~path:(Fpath.v path) ~print_gh_annotation_warnings:true
      in
      let crs =
        Crs_parser.grep ~vcs ~repo_root ~below:Vcs.Path_in_repo.root |> Cr_comment.sort

--- a/lib/crs_cli/src/cmd__tools__github__summary_comment.ml
+++ b/lib/crs_cli/src/cmd__tools__github__summary_comment.ml
@@ -40,7 +40,8 @@ let main =
      let config =
        match config with
        | None -> Config.empty
-       | Some path -> Config.load_exn ~path:(Fpath.v path)
+       | Some path ->
+         Config.load_exn ~path:(Fpath.v path) ~print_gh_annotation_warnings:true
      in
      let annotated_crs =
        Crs_parser.grep ~vcs ~repo_root ~below:Vcs.Path_in_repo.root

--- a/lib/crs_cli/src/cmd__tools__reviewdog__annotate_crs.ml
+++ b/lib/crs_cli/src/cmd__tools__reviewdog__annotate_crs.ml
@@ -37,7 +37,8 @@ let main =
      let config =
        match config with
        | None -> Config.empty
-       | Some path -> Config.load_exn ~path:(Fpath.v path)
+       | Some path ->
+         Config.load_exn ~path:(Fpath.v path) ~print_gh_annotation_warnings:true
      in
      let crs =
        Crs_parser.grep ~vcs ~repo_root ~below:Vcs.Path_in_repo.root |> Cr_comment.sort

--- a/lib/crs_cli/src/common_helpers.ml
+++ b/lib/crs_cli/src/common_helpers.ml
@@ -98,7 +98,7 @@ let with_user_mentions_arg =
        $(i,@assignee-login)), which may trigger a notification in some environments \
        (such as GitHub PR reviews). If false, the assignee's login is shown without the \
        '@', so no notification is triggered. Note: For a notification to be triggered, \
-       the user must also be included in the configured user-mentions whitelist. This \
+       the user must also be included in the configured user-mentions allowlist. This \
        flag only affects notification behavior, as the assignee's name is always \
        displayed."
 ;;

--- a/lib/crs_cli/src/config.ml
+++ b/lib/crs_cli/src/config.ml
@@ -24,7 +24,14 @@ module Annotation_severity = struct
     | Error
     | Warning
     | Info
-  [@@deriving of_yojson, sexp_of]
+  [@@deriving sexp_of]
+
+  let of_string = function
+    | "Error" -> Some Error
+    | "Warning" -> Some Warning
+    | "Info" -> Some Info
+    | _ -> None
+  ;;
 end
 
 open! Ppx_yojson_conv_lib.Yojson_conv.Primitives
@@ -32,33 +39,163 @@ open! Ppx_yojson_conv_lib.Yojson_conv.Primitives
 module User_handle = struct
   type t = Vcs.User_handle.t [@@deriving sexp_of]
 
-  let t_of_yojson json = json |> string_of_yojson |> Vcs.User_handle.v
+  let t_of_yojson json =
+    match json |> string_of_yojson |> Vcs.User_handle.of_string with
+    | Ok t -> t
+    | Error (`Msg msg) ->
+      raise (Ppx_yojson_conv_lib.Yojson_conv.Of_yojson_error (Failure msg, json))
+  ;;
+end
+
+module User_list = struct
+  type t = User_handle.t list [@@deriving of_yojson]
 end
 
 type t =
-  { default_repo_owner : User_handle.t option [@yojson.option] [@sexp.option]
-  ; user_mentions_whitelist : User_handle.t list option [@yojson.option] [@sexp.option]
-  ; invalid_crs_annotation_severity : Annotation_severity.t option
-        [@yojson.option] [@sexp.option]
-  ; crs_due_now_annotation_severity : Annotation_severity.t option
-        [@yojson.option] [@sexp.option]
+  { default_repo_owner : User_handle.t option [@sexp.option]
+  ; user_mentions_allowlist : User_handle.t list option [@sexp.option]
+  ; invalid_crs_annotation_severity : Annotation_severity.t option [@sexp.option]
+  ; crs_due_now_annotation_severity : Annotation_severity.t option [@sexp.option]
   }
-[@@deriving of_yojson, sexp_of]
+[@@deriving sexp_of]
+
+let get_json_field ~loc ~fields ~field_name =
+  match
+    List.filter_map fields ~f:(fun (name, json) ->
+      Option.some_if (String.equal name field_name) json)
+  with
+  | [] -> None
+  | [ f ] -> Some f
+  | _ :: _ :: _ ->
+    Err.raise
+      ~loc
+      Pp.O.
+        [ Pp.text "Json object field "
+          ++ Pp_tty.kwd (module String) field_name
+          ++ Pp.text " is duplicated in this config."
+        ]
+;;
+
+let get_json_enum_constructor json ~loc ~field_name =
+  match json with
+  | `String str -> `Unwrapped str
+  | `List [ `String str ] -> `Wrapped str
+  | _ ->
+    Err.raise
+      ~loc
+      Pp.O.
+        [ Pp.text "In: " ++ Pp.text (Yojson.Safe.to_string json)
+        ; Pp.text "Field "
+          ++ Pp_tty.kwd (module String) field_name
+          ++ Pp.text " expected to be a json string."
+        ]
+;;
+
+let parse_json json ~loc ~print_gh_annotation_warnings =
+  match json with
+  | `Assoc fields ->
+    (* Track which fields have been accessed *)
+    let used_fields = Hash_set.create (module String) in
+    let field field_name =
+      Hash_set.add used_fields field_name;
+      get_json_field ~loc ~fields ~field_name
+    in
+    let default_repo_owner =
+      match field "default_repo_owner" with
+      | Some json -> Some (User_handle.t_of_yojson json)
+      | None -> None
+    in
+    let user_mentions_allowlist =
+      let field_name = "user_mentions_allowlist" in
+      match field field_name with
+      | Some json -> Some (User_list.t_of_yojson json)
+      | None ->
+        (* See [upgrading-crs] guide in the documentation for more details about
+           deprecated fields and compatibility transitions in the configs. *)
+        let deprecated_field_name = "user_mentions_whitelist" in
+        (match field deprecated_field_name with
+         | None -> None
+         | Some json ->
+           User_warning.emit
+             ~loc
+             ~print_gh_annotation_warnings
+             Pp.O.
+               [ Pp.text "The config field name "
+                 ++ Pp_tty.kwd (module String) deprecated_field_name
+                 ++ Pp.text " is deprecated and was renamed "
+                 ++ Pp_tty.kwd (module String) field_name
+                 ++ Pp.text "."
+               ]
+             ~hints:[ Pp.text "Upgrade the config to use the new name." ];
+           Some (User_list.t_of_yojson json))
+    in
+    let severity_field ~field_name =
+      match field field_name with
+      | None -> None
+      | Some json ->
+        let parse_string str =
+          match Annotation_severity.of_string str with
+          | Some t -> t
+          | None ->
+            Err.raise
+              ~loc
+              Pp.O.
+                [ Pp.text "Field " ++ Pp_tty.kwd (module String) field_name ++ Pp.text ":"
+                ; Pp.textf "Unsupported annotation severity %S." str
+                ]
+        in
+        (match get_json_enum_constructor json ~loc ~field_name with
+         | `Unwrapped str -> Some (parse_string str)
+         | `Wrapped str ->
+           let severity = parse_string str in
+           User_warning.emit
+             ~loc
+             ~print_gh_annotation_warnings
+             Pp.O.
+               [ Pp.text "The config field name "
+                 ++ Pp_tty.kwd (module String) field_name
+                 ++ Pp.text " is now expected to be a json string rather than a list."
+               ]
+             ~hints:[ Pp.textf "Change it to simply: %S" str ];
+           Some severity)
+    in
+    let invalid_crs_annotation_severity =
+      severity_field ~field_name:"invalid_crs_annotation_severity"
+    in
+    let crs_due_now_annotation_severity =
+      severity_field ~field_name:"crs_due_now_annotation_severity"
+    in
+    (* Emit warnings for any unknown fields *)
+    List.iter fields ~f:(fun (name, _) ->
+      if not (Hash_set.mem used_fields name)
+      then
+        User_warning.emit
+          ~loc
+          ~print_gh_annotation_warnings
+          Pp.O.[ Pp.text "Unknown config field: " ++ Pp_tty.kwd (module String) name ]
+          ~hints:[ Pp.text "Check the documentation for valid field names." ]);
+    { default_repo_owner
+    ; user_mentions_allowlist
+    ; invalid_crs_annotation_severity
+    ; crs_due_now_annotation_severity
+    }
+  | _ -> Err.raise ~loc [ Pp.text "Config expected to be a json object." ]
+;;
 
 let default_repo_owner t = t.default_repo_owner
-let user_mentions_allowlist t = t.user_mentions_whitelist
+let user_mentions_allowlist t = t.user_mentions_allowlist
 let invalid_crs_annotation_severity t = t.invalid_crs_annotation_severity
 let crs_due_now_annotation_severity t = t.crs_due_now_annotation_severity
 
 let create
       ?default_repo_owner
-      ?user_mentions_allowlist:user_mentions_whitelist
+      ?user_mentions_allowlist
       ?invalid_crs_annotation_severity
       ?crs_due_now_annotation_severity
       ()
   =
   { default_repo_owner
-  ; user_mentions_whitelist
+  ; user_mentions_allowlist
   ; invalid_crs_annotation_severity
   ; crs_due_now_annotation_severity
   }
@@ -66,25 +203,35 @@ let create
 
 let empty =
   { default_repo_owner = None
-  ; user_mentions_whitelist = None
+  ; user_mentions_allowlist = None
   ; invalid_crs_annotation_severity = None
   ; crs_due_now_annotation_severity = None
   }
 ;;
 
-let load_exn ~path =
+let load_exn ~path ~print_gh_annotation_warnings =
   match Yojson_five.Safe.from_file (Fpath.to_string path) with
   | Error msg ->
     Err.raise ~loc:(Loc.of_file ~path) [ Pp.text "Not a valid json file."; Pp.text msg ]
   | Ok json ->
-    (match t_of_yojson json with
-     | t -> t
-     | exception Ppx_yojson_conv_lib.Yojson_conv.Of_yojson_error (exn, json) ->
+    (match
+       match parse_json json ~loc:(Loc.of_file ~path) ~print_gh_annotation_warnings with
+       | t -> Ok t
+       | exception Ppx_yojson_conv_lib.Yojson_conv.Of_yojson_error (exn, json) ->
+         Error (exn, json)
+     with
+     | Ok t -> t
+     | Error (exn, json) ->
+       let msg =
+         match exn with
+         | Failure msg -> Pp.text msg
+         | exn -> Err.exn exn [@coverage off]
+       in
        Err.raise
          ~loc:(Loc.of_file ~path)
          Pp.O.
            [ Pp.text "Invalid config."
            ; Pp.text "In: " ++ Pp.text (Yojson.Safe.to_string json)
-           ; Err.exn exn
+           ; msg
            ])
 ;;

--- a/lib/crs_cli/src/config.ml
+++ b/lib/crs_cli/src/config.ml
@@ -45,9 +45,14 @@ type t =
   }
 [@@deriving of_yojson, sexp_of]
 
+let default_repo_owner t = t.default_repo_owner
+let user_mentions_allowlist t = t.user_mentions_whitelist
+let invalid_crs_annotation_severity t = t.invalid_crs_annotation_severity
+let crs_due_now_annotation_severity t = t.crs_due_now_annotation_severity
+
 let create
       ?default_repo_owner
-      ?user_mentions_whitelist
+      ?user_mentions_allowlist:user_mentions_whitelist
       ?invalid_crs_annotation_severity
       ?crs_due_now_annotation_severity
       ()

--- a/lib/crs_cli/src/config.mli
+++ b/lib/crs_cli/src/config.mli
@@ -74,4 +74,11 @@ val create
   -> t
 
 val empty : t
-val load_exn : path:Fpath.t -> t
+
+(** The loading of the config allows for some compatibility transitions during
+    which deprecated names and or constructs are allowed. However, when they are
+    detected, warnings are emitted. For convenience and help users discover
+    warnings during CI runs, the loading can optionally include CI warnings on
+    stderr for GitHub, using workflow annotations. To activate, supply
+    [print_hg_annotation_warnings:true]. *)
+val load_exn : path:Fpath.t -> print_gh_annotation_warnings:bool -> t

--- a/lib/crs_cli/src/config.mli
+++ b/lib/crs_cli/src/config.mli
@@ -36,8 +36,12 @@ module Annotation_severity : sig
     | Error
     | Warning
     | Info
-  [@@deriving of_yojson, sexp_of]
+  [@@deriving sexp_of]
 end
+
+type t [@@deriving sexp_of]
+
+(** {1 Getters} *)
 
 (** [default_repo_owner] When not in a PR, the default_repo_owner may be used to
     assigned certain kinds of otherwise not easy to assign to a particular user.
@@ -47,23 +51,23 @@ end
     If the repository is owned by an individual, this would typically be that
     user. If the repository is owned by an organization, this may be set to a
     user in particular who would be assigned otherwise unassignable CRs. If it
-    isn't set, such CRs will simply not be assigned to any one in particular.
+    isn't set, such CRs will simply not be assigned to any one in particular. *)
+val default_repo_owner : t -> Vcs.User_handle.t option
 
-    [user_mentions_whitelist] enables a specific list of users to be notified in
+(** [user_mentions_allowlist] enables a specific list of users to be notified in
     annotations comments, when notifications is requested. This is a protection
     measure to avoid spamming users that do not have ties to a repo in
     particular, or simply do not wish to be notified via CRs. *)
-type t =
-  { default_repo_owner : Vcs.User_handle.t option
-  ; user_mentions_whitelist : Vcs.User_handle.t list option
-  ; invalid_crs_annotation_severity : Annotation_severity.t option
-  ; crs_due_now_annotation_severity : Annotation_severity.t option
-  }
-[@@deriving of_yojson, sexp_of]
+val user_mentions_allowlist : t -> Vcs.User_handle.t list option
+
+val invalid_crs_annotation_severity : t -> Annotation_severity.t option
+val crs_due_now_annotation_severity : t -> Annotation_severity.t option
+
+(** {1 Create configs} *)
 
 val create
   :  ?default_repo_owner:Vcs.User_handle.t
-  -> ?user_mentions_whitelist:Vcs.User_handle.t list
+  -> ?user_mentions_allowlist:Vcs.User_handle.t list
   -> ?invalid_crs_annotation_severity:Annotation_severity.t
   -> ?crs_due_now_annotation_severity:Annotation_severity.t
   -> unit

--- a/lib/crs_cli/src/review_mode.ml
+++ b/lib/crs_cli/src/review_mode.ml
@@ -65,34 +65,6 @@ module Name_compatibility = struct
   ;;
 end
 
-let pp_to_string pp =
-  let buffer = Buffer.create 23 in
-  let formatter = Stdlib.Format.formatter_of_buffer buffer in
-  Stdlib.Format.fprintf formatter "%a%!" Pp.to_fmt pp;
-  let contents =
-    Buffer.contents buffer
-    |> String.split_lines
-    |> List.map ~f:(fun s -> String.rstrip s ^ "\n")
-    |> String.concat
-  in
-  contents
-;;
-
-let warning ~print_gh_annotation_warnings messages =
-  Err.warning messages;
-  if print_gh_annotation_warnings
-  then (
-    let github_annotation =
-      Github_annotation.create
-        ~loc:Loc.none
-        ~severity:Warning
-        ~title:"crs"
-        ~message:
-          (String.concat ~sep:"" (List.map messages ~f:pp_to_string) |> String.strip)
-    in
-    prerr_endline (Github_annotation.to_string github_annotation))
-;;
-
 let arg ~print_gh_annotation_warnings =
   let open Command.Std in
   let pull_request_author_switch = "pull-request-author" in
@@ -146,7 +118,7 @@ let arg ~print_gh_annotation_warnings =
           ; Pp.verbatim "Please attend."
           ]
       in
-      warning ~print_gh_annotation_warnings messages
+      User_warning.emit ~print_gh_annotation_warnings messages
   in
   (* Both errors are covered but disabled due to an issue with bisect_ppx out
      edge creating false negative. *)
@@ -205,7 +177,7 @@ let arg ~print_gh_annotation_warnings =
              ; Pp.verbatim "It will become mandatory in the future, please attend."
              ]
          in
-         warning ~print_gh_annotation_warnings messages);
+         User_warning.emit ~print_gh_annotation_warnings messages);
       pull_request_base
     in
     Pull_request { author; base }

--- a/lib/crs_cli/src/user_warning.ml
+++ b/lib/crs_cli/src/user_warning.ml
@@ -1,0 +1,53 @@
+(********************************************************************************)
+(*  crs - A tool for managing code review comments embedded in source code      *)
+(*  Copyright (C) 2024-2025 Mathieu Barbin <mathieu.barbin@gmail.com>           *)
+(*                                                                              *)
+(*  This file is part of crs.                                                   *)
+(*                                                                              *)
+(*  crs is free software; you can redistribute it and/or modify it under the    *)
+(*  terms of the GNU Lesser General Public License as published by the Free     *)
+(*  Software Foundation either version 3 of the License, or any later version,  *)
+(*  with the LGPL-3.0 Linking Exception.                                        *)
+(*                                                                              *)
+(*  crs is distributed in the hope that it will be useful, but WITHOUT ANY      *)
+(*  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS   *)
+(*  FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License and     *)
+(*  the file `NOTICE.md` at the root of this repository for more details.       *)
+(*                                                                              *)
+(*  You should have received a copy of the GNU Lesser General Public License    *)
+(*  and the LGPL-3.0 Linking Exception along with this library. If not, see     *)
+(*  <http://www.gnu.org/licenses/> and <https://spdx.org>, respectively.        *)
+(********************************************************************************)
+
+let pp_to_string pp =
+  let buffer = Buffer.create 23 in
+  let formatter = Stdlib.Format.formatter_of_buffer buffer in
+  Stdlib.Format.fprintf formatter "%a%!" Pp.to_fmt pp;
+  let contents =
+    Buffer.contents buffer
+    |> String.split_lines
+    |> List.map ~f:(fun s -> String.rstrip s ^ "\n")
+    |> String.concat
+  in
+  contents
+;;
+
+let emit ?loc ~print_gh_annotation_warnings ?hints messages =
+  Err.warning ?loc ?hints messages;
+  if print_gh_annotation_warnings
+  then (
+    let message_text = String.concat ~sep:"" (List.map messages ~f:pp_to_string) in
+    let hints_text =
+      match hints with
+      | None -> ""
+      | Some hints -> "Hints: " ^ String.concat ~sep:" " (List.map hints ~f:pp_to_string)
+    in
+    let github_annotation =
+      Github_annotation.create
+        ~loc:(Option.value loc ~default:Loc.none)
+        ~severity:Warning
+        ~title:"crs"
+        ~message:(String.strip (message_text ^ hints_text))
+    in
+    prerr_endline (Github_annotation.to_string github_annotation))
+;;

--- a/lib/crs_cli/src/user_warning.mli
+++ b/lib/crs_cli/src/user_warning.mli
@@ -1,0 +1,47 @@
+(*_*******************************************************************************)
+(*_  crs - A tool for managing code review comments embedded in source code      *)
+(*_  Copyright (C) 2024-2025 Mathieu Barbin <mathieu.barbin@gmail.com>           *)
+(*_                                                                              *)
+(*_  This file is part of crs.                                                   *)
+(*_                                                                              *)
+(*_  crs is free software; you can redistribute it and/or modify it under the    *)
+(*_  terms of the GNU Lesser General Public License as published by the Free     *)
+(*_  Software Foundation either version 3 of the License, or any later version,  *)
+(*_  with the LGPL-3.0 Linking Exception.                                        *)
+(*_                                                                              *)
+(*_  crs is distributed in the hope that it will be useful, but WITHOUT ANY      *)
+(*_  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS   *)
+(*_  FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License and     *)
+(*_  the file `NOTICE.md` at the root of this repository for more details.       *)
+(*_                                                                              *)
+(*_  You should have received a copy of the GNU Lesser General Public License    *)
+(*_  and the LGPL-3.0 Linking Exception along with this library. If not, see     *)
+(*_  <http://www.gnu.org/licenses/> and <https://spdx.org>, respectively.        *)
+(*_*******************************************************************************)
+
+(** A helper module to create warnings that may be highlighted by GitHub
+    Annotations for accrued discoverability.
+
+    For use in GitHub workflows. *)
+
+(** Emit a warning with [Err.warning] with the supplied messages. For
+    convenience and help users discover warnings during CI runs, this can
+    optionally include CI warnings on stderr for GitHub, using workflow
+    annotations. To activate, supply [print_gh_annotation_warnings:true].
+
+    {b Motivation:} When running in CI/CD environments, warnings printed to stderr
+    can easily be missed among other output. GitHub workflow annotations provide
+    a way to surface these warnings prominently in the GitHub UI, appearing both
+    in the workflow run summary and as inline annotations in pull requests. This
+    significantly improves the discoverability of warnings that might otherwise
+    go unnoticed, helping developers address issues before merging code.
+
+    The optional [hints] parameter provides additional context or suggestions
+    for resolving the warning. When GitHub annotations are enabled, hints are
+    included in the annotation message with a "Hints: " prefix. *)
+val emit
+  :  ?loc:Loc.t
+  -> print_gh_annotation_warnings:bool
+  -> ?hints:Pp_tty.t list
+  -> Pp_tty.t list
+  -> unit

--- a/lib/crs_cli/test/test__annotation.ml
+++ b/lib/crs_cli/test/test__annotation.ml
@@ -172,7 +172,7 @@ let%expect_test "compute" =
   let config =
     let user = Vcs.User_handle.v "user" in
     let user2 = Vcs.User_handle.v "user2" in
-    Config.create ~default_repo_owner:user ~user_mentions_whitelist:[ user; user2 ] ()
+    Config.create ~default_repo_owner:user ~user_mentions_allowlist:[ user; user2 ] ()
   in
   test Tests_helpers.test_cases ~config ~review_mode:Revision ~with_user_mentions:true;
   [%expect
@@ -208,7 +208,7 @@ let%expect_test "compute" =
     XCR-someday user: Hello.
     Info: This XCR is assigned to @user (CR reporter).
     |}];
-  (* Here user3 should not be notified because they are not in the whitelist. *)
+  (* Here user3 should not be notified because they are not in the allowlist. *)
   test
     "(* $CR user for user3: Hello. *)"
     ~config

--- a/test/cram/annotate-crs.t
+++ b/test/cram/annotate-crs.t
@@ -74,6 +74,23 @@ Let's add a config.
   > EOF
 
   $ crs tools github annotate-crs --config=crs-config.json
+  File "crs-config.json", line 1, characters 0-0:
+  Warning: The config field name [user_mentions_whitelist] is deprecated and
+  was renamed [user_mentions_allowlist].
+  Hint: Upgrade the config to use the new name.
+  ::warning file=crs-config.json,line=1,col=1,endLine=1,endColumn=1,title=crs::The config field name [user_mentions_whitelist] is deprecated and was renamed%0A[user_mentions_allowlist].%0AHints: Upgrade the config to use the new%0Aname.
+  
+  File "crs-config.json", line 1, characters 0-0:
+  Warning: The config field name [invalid_crs_annotation_severity] is now
+  expected to be a json string rather than a list.
+  Hint: Change it to simply: "Warning"
+  ::warning file=crs-config.json,line=1,col=1,endLine=1,endColumn=1,title=crs::The config field name [invalid_crs_annotation_severity] is now expected to be%0Aa json string rather than a%0Alist.%0AHints: Change it to simply:%0A"Warning"
+  
+  File "crs-config.json", line 1, characters 0-0:
+  Warning: The config field name [crs_due_now_annotation_severity] is now
+  expected to be a json string rather than a list.
+  Hint: Change it to simply: "Info"
+  ::warning file=crs-config.json,line=1,col=1,endLine=1,endColumn=1,title=crs::The config field name [crs_due_now_annotation_severity] is now expected to be%0Aa json string rather than a%0Alist.%0AHints: Change it to simply:%0A"Info"
   ::notice file=foo/a.txt,line=2,col=1,endLine=2,endColumn=39,title=XCR::This XCR is assigned to user1 (CR reporter).
   ::notice file=foo/foo.c,line=1,col=1,endLine=1,endColumn=61,title=CR::This CR is assigned to user3 (CR recipient).
   ::notice file=foo/pr.ml,line=1,col=1,endLine=1,endColumn=51,title=CR::This CR is assigned to user1 (default repo owner).
@@ -87,6 +104,24 @@ Test it in the context of a pull review too.
   Warning: Review mode [pull-request] requires [--pull-request-base].
   It will become mandatory in the future, please attend.
   ::warning title=crs::Review mode [pull-request] requires [--pull-request-base].%0AIt will become mandatory in the future, please attend.
+  
+  File "crs-config.json", line 1, characters 0-0:
+  Warning: The config field name [user_mentions_whitelist] is deprecated and
+  was renamed [user_mentions_allowlist].
+  Hint: Upgrade the config to use the new name.
+  ::warning file=crs-config.json,line=1,col=1,endLine=1,endColumn=1,title=crs::The config field name [user_mentions_whitelist] is deprecated and was renamed%0A[user_mentions_allowlist].%0AHints: Upgrade the config to use the new%0Aname.
+  
+  File "crs-config.json", line 1, characters 0-0:
+  Warning: The config field name [invalid_crs_annotation_severity] is now
+  expected to be a json string rather than a list.
+  Hint: Change it to simply: "Warning"
+  ::warning file=crs-config.json,line=1,col=1,endLine=1,endColumn=1,title=crs::The config field name [invalid_crs_annotation_severity] is now expected to be%0Aa json string rather than a%0Alist.%0AHints: Change it to simply:%0A"Warning"
+  
+  File "crs-config.json", line 1, characters 0-0:
+  Warning: The config field name [crs_due_now_annotation_severity] is now
+  expected to be a json string rather than a list.
+  Hint: Change it to simply: "Info"
+  ::warning file=crs-config.json,line=1,col=1,endLine=1,endColumn=1,title=crs::The config field name [crs_due_now_annotation_severity] is now expected to be%0Aa json string rather than a%0Alist.%0AHints: Change it to simply:%0A"Info"
   ::notice file=foo/a.txt,line=2,col=1,endLine=2,endColumn=39,title=XCR::This XCR is assigned to user1 (CR reporter).
   ::notice file=foo/foo.c,line=1,col=1,endLine=1,endColumn=61,title=CR::This CR is assigned to user3 (CR recipient).
   ::notice file=foo/pr.ml,line=1,col=1,endLine=1,endColumn=51,title=CR::This CR is assigned to pr-author (PR author).
@@ -98,6 +133,23 @@ Let's add the required base revision.
   >   --review-mode=pull-request \
   >   --pull-request-author="pr-author" \
   >   --pull-request-base="${rev0}"
+  File "crs-config.json", line 1, characters 0-0:
+  Warning: The config field name [user_mentions_whitelist] is deprecated and
+  was renamed [user_mentions_allowlist].
+  Hint: Upgrade the config to use the new name.
+  ::warning file=crs-config.json,line=1,col=1,endLine=1,endColumn=1,title=crs::The config field name [user_mentions_whitelist] is deprecated and was renamed%0A[user_mentions_allowlist].%0AHints: Upgrade the config to use the new%0Aname.
+  
+  File "crs-config.json", line 1, characters 0-0:
+  Warning: The config field name [invalid_crs_annotation_severity] is now
+  expected to be a json string rather than a list.
+  Hint: Change it to simply: "Warning"
+  ::warning file=crs-config.json,line=1,col=1,endLine=1,endColumn=1,title=crs::The config field name [invalid_crs_annotation_severity] is now expected to be%0Aa json string rather than a%0Alist.%0AHints: Change it to simply:%0A"Warning"
+  
+  File "crs-config.json", line 1, characters 0-0:
+  Warning: The config field name [crs_due_now_annotation_severity] is now
+  expected to be a json string rather than a list.
+  Hint: Change it to simply: "Info"
+  ::warning file=crs-config.json,line=1,col=1,endLine=1,endColumn=1,title=crs::The config field name [crs_due_now_annotation_severity] is now expected to be%0Aa json string rather than a%0Alist.%0AHints: Change it to simply:%0A"Info"
   ::notice file=foo/a.txt,line=2,col=1,endLine=2,endColumn=39,title=XCR::This XCR is assigned to user1 (CR reporter).
   ::notice file=foo/foo.c,line=1,col=1,endLine=1,endColumn=61,title=CR::This CR is assigned to user3 (CR recipient).
   ::notice file=foo/pr.ml,line=1,col=1,endLine=1,endColumn=51,title=CR::This CR is assigned to pr-author (PR author).
@@ -162,6 +214,23 @@ Let's test the reviewdog annotations too.
   }
 
   $ crs tools reviewdog annotate-crs --config=crs-config.json > with-config
+  File "crs-config.json", line 1, characters 0-0:
+  Warning: The config field name [user_mentions_whitelist] is deprecated and
+  was renamed [user_mentions_allowlist].
+  Hint: Upgrade the config to use the new name.
+  ::warning file=crs-config.json,line=1,col=1,endLine=1,endColumn=1,title=crs::The config field name [user_mentions_whitelist] is deprecated and was renamed%0A[user_mentions_allowlist].%0AHints: Upgrade the config to use the new%0Aname.
+  
+  File "crs-config.json", line 1, characters 0-0:
+  Warning: The config field name [invalid_crs_annotation_severity] is now
+  expected to be a json string rather than a list.
+  Hint: Change it to simply: "Warning"
+  ::warning file=crs-config.json,line=1,col=1,endLine=1,endColumn=1,title=crs::The config field name [invalid_crs_annotation_severity] is now expected to be%0Aa json string rather than a%0Alist.%0AHints: Change it to simply:%0A"Warning"
+  
+  File "crs-config.json", line 1, characters 0-0:
+  Warning: The config field name [crs_due_now_annotation_severity] is now
+  expected to be a json string rather than a list.
+  Hint: Change it to simply: "Info"
+  ::warning file=crs-config.json,line=1,col=1,endLine=1,endColumn=1,title=crs::The config field name [crs_due_now_annotation_severity] is now expected to be%0Aa json string rather than a%0Alist.%0AHints: Change it to simply:%0A"Info"
 
   $ diff without-config with-config
   30c30
@@ -176,6 +245,23 @@ Let's test the reviewdog annotations too.
   >   --pull-request-base="${rev0}" \
   >   --with-user-mentions=true \
   >  > for-pull-request
+  File "crs-config.json", line 1, characters 0-0:
+  Warning: The config field name [user_mentions_whitelist] is deprecated and
+  was renamed [user_mentions_allowlist].
+  Hint: Upgrade the config to use the new name.
+  ::warning file=crs-config.json,line=1,col=1,endLine=1,endColumn=1,title=crs::The config field name [user_mentions_whitelist] is deprecated and was renamed%0A[user_mentions_allowlist].%0AHints: Upgrade the config to use the new%0Aname.
+  
+  File "crs-config.json", line 1, characters 0-0:
+  Warning: The config field name [invalid_crs_annotation_severity] is now
+  expected to be a json string rather than a list.
+  Hint: Change it to simply: "Warning"
+  ::warning file=crs-config.json,line=1,col=1,endLine=1,endColumn=1,title=crs::The config field name [invalid_crs_annotation_severity] is now expected to be%0Aa json string rather than a%0Alist.%0AHints: Change it to simply:%0A"Warning"
+  
+  File "crs-config.json", line 1, characters 0-0:
+  Warning: The config field name [crs_due_now_annotation_severity] is now
+  expected to be a json string rather than a list.
+  Hint: Change it to simply: "Info"
+  ::warning file=crs-config.json,line=1,col=1,endLine=1,endColumn=1,title=crs::The config field name [crs_due_now_annotation_severity] is now expected to be%0Aa json string rather than a%0Alist.%0AHints: Change it to simply:%0A"Info"
 
   $ diff with-config for-pull-request
   6c6
@@ -214,6 +300,23 @@ We can also print a summary comment,
   >   --pull-request-base="${rev0}" \
   >   --with-user-mentions=true \
   >  > for-pull-request
+  File "crs-config.json", line 1, characters 0-0:
+  Warning: The config field name [user_mentions_whitelist] is deprecated and
+  was renamed [user_mentions_allowlist].
+  Hint: Upgrade the config to use the new name.
+  ::warning file=crs-config.json,line=1,col=1,endLine=1,endColumn=1,title=crs::The config field name [user_mentions_whitelist] is deprecated and was renamed%0A[user_mentions_allowlist].%0AHints: Upgrade the config to use the new%0Aname.
+  
+  File "crs-config.json", line 1, characters 0-0:
+  Warning: The config field name [invalid_crs_annotation_severity] is now
+  expected to be a json string rather than a list.
+  Hint: Change it to simply: "Warning"
+  ::warning file=crs-config.json,line=1,col=1,endLine=1,endColumn=1,title=crs::The config field name [invalid_crs_annotation_severity] is now expected to be%0Aa json string rather than a%0Alist.%0AHints: Change it to simply:%0A"Warning"
+  
+  File "crs-config.json", line 1, characters 0-0:
+  Warning: The config field name [crs_due_now_annotation_severity] is now
+  expected to be a json string rather than a list.
+  Hint: Change it to simply: "Info"
+  ::warning file=crs-config.json,line=1,col=1,endLine=1,endColumn=1,title=crs::The config field name [crs_due_now_annotation_severity] is now expected to be%0Aa json string rather than a%0Alist.%0AHints: Change it to simply:%0A"Info"
 
   $ diff without-config for-pull-request
   12c12

--- a/test/cram/annotate-crs.t
+++ b/test/cram/annotate-crs.t
@@ -67,30 +67,34 @@ Let's add a config.
 
   $ cat > crs-config.json <<EOF
   > { default_repo_owner: "user1"
-  > , user_mentions_whitelist: [ "user1", "user2", "pr-author" ]
-  > , invalid_crs_annotation_severity: [ "Warning" ]
-  > , crs_due_now_annotation_severity: [ "Info" ]
+  > , user_mentions_allowlist: [ "user1", "user2", "pr-author" ]
+  > , invalid_crs_annotation_severity: "Warning"
+  > , crs_due_now_annotation_severity: "Info"
   > }
   > EOF
 
-  $ crs tools github annotate-crs --config=crs-config.json
-  File "crs-config.json", line 1, characters 0-0:
+Test that deprecated field generates a warning with GitHub annotations.
+
+  $ cat > crs-config-deprecated.json <<EOF
+  > { default_repo_owner: "user1"
+  > , user_mentions_whitelist: [ "user1", "user2", "pr-author" ]
+  > , invalid_crs_annotation_severity: "Warning"
+  > , crs_due_now_annotation_severity: "Info"
+  > }
+  > EOF
+
+  $ crs tools github annotate-crs --config=crs-config-deprecated.json
+  File "crs-config-deprecated.json", line 1, characters 0-0:
   Warning: The config field name [user_mentions_whitelist] is deprecated and
   was renamed [user_mentions_allowlist].
   Hint: Upgrade the config to use the new name.
-  ::warning file=crs-config.json,line=1,col=1,endLine=1,endColumn=1,title=crs::The config field name [user_mentions_whitelist] is deprecated and was renamed%0A[user_mentions_allowlist].%0AHints: Upgrade the config to use the new%0Aname.
-  
-  File "crs-config.json", line 1, characters 0-0:
-  Warning: The config field name [invalid_crs_annotation_severity] is now
-  expected to be a json string rather than a list.
-  Hint: Change it to simply: "Warning"
-  ::warning file=crs-config.json,line=1,col=1,endLine=1,endColumn=1,title=crs::The config field name [invalid_crs_annotation_severity] is now expected to be%0Aa json string rather than a%0Alist.%0AHints: Change it to simply:%0A"Warning"
-  
-  File "crs-config.json", line 1, characters 0-0:
-  Warning: The config field name [crs_due_now_annotation_severity] is now
-  expected to be a json string rather than a list.
-  Hint: Change it to simply: "Info"
-  ::warning file=crs-config.json,line=1,col=1,endLine=1,endColumn=1,title=crs::The config field name [crs_due_now_annotation_severity] is now expected to be%0Aa json string rather than a%0Alist.%0AHints: Change it to simply:%0A"Info"
+  ::warning file=crs-config-deprecated.json,line=1,col=1,endLine=1,endColumn=1,title=crs::The config field name [user_mentions_whitelist] is deprecated and was renamed%0A[user_mentions_allowlist].%0AHints: Upgrade the config to use the new%0Aname.
+  ::notice file=foo/a.txt,line=2,col=1,endLine=2,endColumn=39,title=XCR::This XCR is assigned to user1 (CR reporter).
+  ::notice file=foo/foo.c,line=1,col=1,endLine=1,endColumn=61,title=CR::This CR is assigned to user3 (CR recipient).
+  ::notice file=foo/pr.ml,line=1,col=1,endLine=1,endColumn=51,title=CR::This CR is assigned to user1 (default repo owner).
+  ::notice file=hello,line=2,col=1,endLine=2,endColumn=61,title=CR::This CR is assigned to user2 (CR recipient).
+
+  $ crs tools github annotate-crs --config=crs-config.json
   ::notice file=foo/a.txt,line=2,col=1,endLine=2,endColumn=39,title=XCR::This XCR is assigned to user1 (CR reporter).
   ::notice file=foo/foo.c,line=1,col=1,endLine=1,endColumn=61,title=CR::This CR is assigned to user3 (CR recipient).
   ::notice file=foo/pr.ml,line=1,col=1,endLine=1,endColumn=51,title=CR::This CR is assigned to user1 (default repo owner).
@@ -104,24 +108,6 @@ Test it in the context of a pull review too.
   Warning: Review mode [pull-request] requires [--pull-request-base].
   It will become mandatory in the future, please attend.
   ::warning title=crs::Review mode [pull-request] requires [--pull-request-base].%0AIt will become mandatory in the future, please attend.
-  
-  File "crs-config.json", line 1, characters 0-0:
-  Warning: The config field name [user_mentions_whitelist] is deprecated and
-  was renamed [user_mentions_allowlist].
-  Hint: Upgrade the config to use the new name.
-  ::warning file=crs-config.json,line=1,col=1,endLine=1,endColumn=1,title=crs::The config field name [user_mentions_whitelist] is deprecated and was renamed%0A[user_mentions_allowlist].%0AHints: Upgrade the config to use the new%0Aname.
-  
-  File "crs-config.json", line 1, characters 0-0:
-  Warning: The config field name [invalid_crs_annotation_severity] is now
-  expected to be a json string rather than a list.
-  Hint: Change it to simply: "Warning"
-  ::warning file=crs-config.json,line=1,col=1,endLine=1,endColumn=1,title=crs::The config field name [invalid_crs_annotation_severity] is now expected to be%0Aa json string rather than a%0Alist.%0AHints: Change it to simply:%0A"Warning"
-  
-  File "crs-config.json", line 1, characters 0-0:
-  Warning: The config field name [crs_due_now_annotation_severity] is now
-  expected to be a json string rather than a list.
-  Hint: Change it to simply: "Info"
-  ::warning file=crs-config.json,line=1,col=1,endLine=1,endColumn=1,title=crs::The config field name [crs_due_now_annotation_severity] is now expected to be%0Aa json string rather than a%0Alist.%0AHints: Change it to simply:%0A"Info"
   ::notice file=foo/a.txt,line=2,col=1,endLine=2,endColumn=39,title=XCR::This XCR is assigned to user1 (CR reporter).
   ::notice file=foo/foo.c,line=1,col=1,endLine=1,endColumn=61,title=CR::This CR is assigned to user3 (CR recipient).
   ::notice file=foo/pr.ml,line=1,col=1,endLine=1,endColumn=51,title=CR::This CR is assigned to pr-author (PR author).
@@ -133,23 +119,6 @@ Let's add the required base revision.
   >   --review-mode=pull-request \
   >   --pull-request-author="pr-author" \
   >   --pull-request-base="${rev0}"
-  File "crs-config.json", line 1, characters 0-0:
-  Warning: The config field name [user_mentions_whitelist] is deprecated and
-  was renamed [user_mentions_allowlist].
-  Hint: Upgrade the config to use the new name.
-  ::warning file=crs-config.json,line=1,col=1,endLine=1,endColumn=1,title=crs::The config field name [user_mentions_whitelist] is deprecated and was renamed%0A[user_mentions_allowlist].%0AHints: Upgrade the config to use the new%0Aname.
-  
-  File "crs-config.json", line 1, characters 0-0:
-  Warning: The config field name [invalid_crs_annotation_severity] is now
-  expected to be a json string rather than a list.
-  Hint: Change it to simply: "Warning"
-  ::warning file=crs-config.json,line=1,col=1,endLine=1,endColumn=1,title=crs::The config field name [invalid_crs_annotation_severity] is now expected to be%0Aa json string rather than a%0Alist.%0AHints: Change it to simply:%0A"Warning"
-  
-  File "crs-config.json", line 1, characters 0-0:
-  Warning: The config field name [crs_due_now_annotation_severity] is now
-  expected to be a json string rather than a list.
-  Hint: Change it to simply: "Info"
-  ::warning file=crs-config.json,line=1,col=1,endLine=1,endColumn=1,title=crs::The config field name [crs_due_now_annotation_severity] is now expected to be%0Aa json string rather than a%0Alist.%0AHints: Change it to simply:%0A"Info"
   ::notice file=foo/a.txt,line=2,col=1,endLine=2,endColumn=39,title=XCR::This XCR is assigned to user1 (CR reporter).
   ::notice file=foo/foo.c,line=1,col=1,endLine=1,endColumn=61,title=CR::This CR is assigned to user3 (CR recipient).
   ::notice file=foo/pr.ml,line=1,col=1,endLine=1,endColumn=51,title=CR::This CR is assigned to pr-author (PR author).
@@ -214,23 +183,6 @@ Let's test the reviewdog annotations too.
   }
 
   $ crs tools reviewdog annotate-crs --config=crs-config.json > with-config
-  File "crs-config.json", line 1, characters 0-0:
-  Warning: The config field name [user_mentions_whitelist] is deprecated and
-  was renamed [user_mentions_allowlist].
-  Hint: Upgrade the config to use the new name.
-  ::warning file=crs-config.json,line=1,col=1,endLine=1,endColumn=1,title=crs::The config field name [user_mentions_whitelist] is deprecated and was renamed%0A[user_mentions_allowlist].%0AHints: Upgrade the config to use the new%0Aname.
-  
-  File "crs-config.json", line 1, characters 0-0:
-  Warning: The config field name [invalid_crs_annotation_severity] is now
-  expected to be a json string rather than a list.
-  Hint: Change it to simply: "Warning"
-  ::warning file=crs-config.json,line=1,col=1,endLine=1,endColumn=1,title=crs::The config field name [invalid_crs_annotation_severity] is now expected to be%0Aa json string rather than a%0Alist.%0AHints: Change it to simply:%0A"Warning"
-  
-  File "crs-config.json", line 1, characters 0-0:
-  Warning: The config field name [crs_due_now_annotation_severity] is now
-  expected to be a json string rather than a list.
-  Hint: Change it to simply: "Info"
-  ::warning file=crs-config.json,line=1,col=1,endLine=1,endColumn=1,title=crs::The config field name [crs_due_now_annotation_severity] is now expected to be%0Aa json string rather than a%0Alist.%0AHints: Change it to simply:%0A"Info"
 
   $ diff without-config with-config
   30c30
@@ -245,23 +197,6 @@ Let's test the reviewdog annotations too.
   >   --pull-request-base="${rev0}" \
   >   --with-user-mentions=true \
   >  > for-pull-request
-  File "crs-config.json", line 1, characters 0-0:
-  Warning: The config field name [user_mentions_whitelist] is deprecated and
-  was renamed [user_mentions_allowlist].
-  Hint: Upgrade the config to use the new name.
-  ::warning file=crs-config.json,line=1,col=1,endLine=1,endColumn=1,title=crs::The config field name [user_mentions_whitelist] is deprecated and was renamed%0A[user_mentions_allowlist].%0AHints: Upgrade the config to use the new%0Aname.
-  
-  File "crs-config.json", line 1, characters 0-0:
-  Warning: The config field name [invalid_crs_annotation_severity] is now
-  expected to be a json string rather than a list.
-  Hint: Change it to simply: "Warning"
-  ::warning file=crs-config.json,line=1,col=1,endLine=1,endColumn=1,title=crs::The config field name [invalid_crs_annotation_severity] is now expected to be%0Aa json string rather than a%0Alist.%0AHints: Change it to simply:%0A"Warning"
-  
-  File "crs-config.json", line 1, characters 0-0:
-  Warning: The config field name [crs_due_now_annotation_severity] is now
-  expected to be a json string rather than a list.
-  Hint: Change it to simply: "Info"
-  ::warning file=crs-config.json,line=1,col=1,endLine=1,endColumn=1,title=crs::The config field name [crs_due_now_annotation_severity] is now expected to be%0Aa json string rather than a%0Alist.%0AHints: Change it to simply:%0A"Info"
 
   $ diff with-config for-pull-request
   6c6
@@ -300,23 +235,6 @@ We can also print a summary comment,
   >   --pull-request-base="${rev0}" \
   >   --with-user-mentions=true \
   >  > for-pull-request
-  File "crs-config.json", line 1, characters 0-0:
-  Warning: The config field name [user_mentions_whitelist] is deprecated and
-  was renamed [user_mentions_allowlist].
-  Hint: Upgrade the config to use the new name.
-  ::warning file=crs-config.json,line=1,col=1,endLine=1,endColumn=1,title=crs::The config field name [user_mentions_whitelist] is deprecated and was renamed%0A[user_mentions_allowlist].%0AHints: Upgrade the config to use the new%0Aname.
-  
-  File "crs-config.json", line 1, characters 0-0:
-  Warning: The config field name [invalid_crs_annotation_severity] is now
-  expected to be a json string rather than a list.
-  Hint: Change it to simply: "Warning"
-  ::warning file=crs-config.json,line=1,col=1,endLine=1,endColumn=1,title=crs::The config field name [invalid_crs_annotation_severity] is now expected to be%0Aa json string rather than a%0Alist.%0AHints: Change it to simply:%0A"Warning"
-  
-  File "crs-config.json", line 1, characters 0-0:
-  Warning: The config field name [crs_due_now_annotation_severity] is now
-  expected to be a json string rather than a list.
-  Hint: Change it to simply: "Info"
-  ::warning file=crs-config.json,line=1,col=1,endLine=1,endColumn=1,title=crs::The config field name [crs_due_now_annotation_severity] is now expected to be%0Aa json string rather than a%0Alist.%0AHints: Change it to simply:%0A"Info"
 
   $ diff without-config for-pull-request
   12c12

--- a/test/cram/validate-config.t
+++ b/test/cram/validate-config.t
@@ -28,42 +28,14 @@ Let's try with valid configs.
 
   $ cat > crs-config.json <<EOF
   > { default_repo_owner: "user1"
-  > , user_mentions_whitelist: [ "user1", "user2", "pr-author" ]
-  > , invalid_crs_annotation_severity: [ "Warning" ]
-  > , crs_due_now_annotation_severity: [ "Info" ]
+  > , user_mentions_allowlist: [ "user1", "user2", "pr-author" ]
+  > , invalid_crs_annotation_severity: "Warning"
+  > , crs_due_now_annotation_severity: "Info"
   > }
   > EOF
 
   $ crs tools config validate crs-config.json
-  File "crs-config.json", line 1, characters 0-0:
-  Warning: The config field name [user_mentions_whitelist] is deprecated and
-  was renamed [user_mentions_allowlist].
-  Hint: Upgrade the config to use the new name.
-  
-  File "crs-config.json", line 1, characters 0-0:
-  Warning: The config field name [invalid_crs_annotation_severity] is now
-  expected to be a json string rather than a list.
-  Hint: Change it to simply: "Warning"
-  
-  File "crs-config.json", line 1, characters 0-0:
-  Warning: The config field name [crs_due_now_annotation_severity] is now
-  expected to be a json string rather than a list.
-  Hint: Change it to simply: "Info"
   $ crs tools config validate crs-config.json --print
-  File "crs-config.json", line 1, characters 0-0:
-  Warning: The config field name [user_mentions_whitelist] is deprecated and
-  was renamed [user_mentions_allowlist].
-  Hint: Upgrade the config to use the new name.
-  
-  File "crs-config.json", line 1, characters 0-0:
-  Warning: The config field name [invalid_crs_annotation_severity] is now
-  expected to be a json string rather than a list.
-  Hint: Change it to simply: "Warning"
-  
-  File "crs-config.json", line 1, characters 0-0:
-  Warning: The config field name [crs_due_now_annotation_severity] is now
-  expected to be a json string rather than a list.
-  Hint: Change it to simply: "Info"
   ((default_repo_owner user1) (user_mentions_allowlist (user1 user2 pr-author))
    (invalid_crs_annotation_severity Warning)
    (crs_due_now_annotation_severity Info))
@@ -71,14 +43,10 @@ Let's try with valid configs.
 Fields are usually optional.
 
   $ cat > crs-config.json <<EOF
-  > { invalid_crs_annotation_severity: [ "Error" ] }
+  > { invalid_crs_annotation_severity: "Error" }
   > EOF
 
   $ crs tools config validate crs-config.json --print
-  File "crs-config.json", line 1, characters 0-0:
-  Warning: The config field name [invalid_crs_annotation_severity] is now
-  expected to be a json string rather than a list.
-  Hint: Change it to simply: "Error"
   ((invalid_crs_annotation_severity Error))
 
 Unknown field.
@@ -87,8 +55,7 @@ Unknown field.
   > { unknown_field: "Hello" }
   > EOF
 
-  $ crs tools config validate crs-config.json >out 2>&1
-  $ cat out | sed 's/[a-zA-Z0-9._\/-]*config\.ml/<PATH>\/config.ml/g'
+  $ crs tools config validate crs-config.json
   File "crs-config.json", line 1, characters 0-0:
   Warning: Unknown config field: [unknown_field]
   Hint: Check the documentation for valid field names.
@@ -96,12 +63,11 @@ Unknown field.
 Invalid value.
 
   $ cat > crs-config.json <<EOF
-  > { invalid_crs_annotation_severity: [ "Unknown" ] }
+  > { invalid_crs_annotation_severity: "Unknown" }
   > EOF
 
-  $ crs tools config validate crs-config.json >out 2>&1
-  [123]
-  $ cat out | sed 's/[a-zA-Z0-9._\/-]*config\.ml/<PATH>\/config.ml/g'
+  $ crs tools config validate crs-config.json
   File "crs-config.json", line 1, characters 0-0:
   Error: Field [invalid_crs_annotation_severity]:
   Unsupported annotation severity "Unknown".
+  [123]

--- a/test/cram/validate-config.t
+++ b/test/cram/validate-config.t
@@ -49,6 +49,39 @@ Fields are usually optional.
   $ crs tools config validate crs-config.json --print
   ((invalid_crs_annotation_severity Error))
 
+Wrapped variants. At this time we allow both representation for variants,
+wrapped in a list and unwrapped. The goal is to deprecate the wrapper version
+at some future point.
+
+  $ cat > crs-config.json <<EOF
+  > { invalid_crs_annotation_severity: [ "Warning" ]
+  > , crs_due_now_annotation_severity: [ "Info" ]
+  > }
+  > EOF
+
+  $ crs tools config validate crs-config.json
+  File "crs-config.json", line 1, characters 0-0:
+  Warning: The config field name [invalid_crs_annotation_severity] is now
+  expected to be a json string rather than a list.
+  Hint: Change it to simply: "Warning"
+  
+  File "crs-config.json", line 1, characters 0-0:
+  Warning: The config field name [crs_due_now_annotation_severity] is now
+  expected to be a json string rather than a list.
+  Hint: Change it to simply: "Info"
+  $ crs tools config validate crs-config.json --print
+  File "crs-config.json", line 1, characters 0-0:
+  Warning: The config field name [invalid_crs_annotation_severity] is now
+  expected to be a json string rather than a list.
+  Hint: Change it to simply: "Warning"
+  
+  File "crs-config.json", line 1, characters 0-0:
+  Warning: The config field name [crs_due_now_annotation_severity] is now
+  expected to be a json string rather than a list.
+  Hint: Change it to simply: "Info"
+  ((invalid_crs_annotation_severity Warning)
+   (crs_due_now_annotation_severity Info))
+
 Unknown field.
 
   $ cat > crs-config.json <<EOF
@@ -71,3 +104,118 @@ Invalid value.
   Error: Field [invalid_crs_annotation_severity]:
   Unsupported annotation severity "Unknown".
   [123]
+
+Test that config must be a JSON object (not an array or other type).
+
+  $ cat > crs-config.json <<EOF
+  > [ "not", "an", "object" ]
+  > EOF
+
+  $ crs tools config validate crs-config.json
+  File "crs-config.json", line 1, characters 0-0:
+  Error: Config expected to be a json object.
+  [123]
+
+Test severity field with invalid type (integer instead of string).
+
+  $ cat > crs-config.json <<EOF
+  > { invalid_crs_annotation_severity: 42 }
+  > EOF
+
+  $ crs tools config validate crs-config.json
+  File "crs-config.json", line 1, characters 0-0:
+  Error: In: 42
+  Field [invalid_crs_annotation_severity] expected to be a json string.
+  [123]
+
+Test severity field with invalid type (object instead of string).
+
+  $ cat > crs-config.json <<EOF
+  > { crs_due_now_annotation_severity: { "nested": "object" } }
+  > EOF
+
+  $ crs tools config validate crs-config.json
+  File "crs-config.json", line 1, characters 0-0:
+  Error: In: {"nested":"object"}
+  Field [crs_due_now_annotation_severity] expected to be a json string.
+  [123]
+
+Test duplicate field detection.
+
+  $ cat > crs-config.json <<EOF
+  > { default_repo_owner: "user1"
+  > , default_repo_owner: "user2"
+  > }
+  > EOF
+
+  $ crs tools config validate crs-config.json
+  File "crs-config.json", line 1, characters 0-0:
+  Error: Json object field [default_repo_owner] is duplicated in this config.
+  [123]
+
+Test malformed JSON file.
+
+  $ echo "{ invalid json" > crs-config.json
+  $ crs tools config validate crs-config.json
+  File "crs-config.json", line 1, characters 0-0:
+  Error: Not a valid json file.
+  Line 1: Expected ':' but found IDENTIFIER_NAME "json"
+  [123]
+
+Test invalid type for user handle (should be string, not array).
+
+  $ cat > crs-config.json <<EOF
+  > { default_repo_owner: ["not", "a", "string"] }
+  > EOF
+
+  $ crs tools config validate crs-config.json
+  File "crs-config.json", line 1, characters 0-0:
+  Error: Invalid config.
+  In: ["not","a","string"]
+  string_of_yojson: string needed
+  [123]
+
+Test invalid user handle with forbidden characters.
+
+  $ cat > crs-config.json <<EOF
+  > { default_repo_owner: "user@with@invalid@chars" }
+  > EOF
+
+  $ crs tools config validate crs-config.json
+  File "crs-config.json", line 1, characters 0-0:
+  Error: Invalid config.
+  In: "user@with@invalid@chars"
+  "user@with@invalid@chars": invalid user_handle
+  [123]
+
+Test user_mentions_allowlist with invalid type (integer instead of list).
+
+  $ cat > crs-config.json <<EOF
+  > { user_mentions_allowlist: 42 }
+  > EOF
+
+  $ crs tools config validate crs-config.json
+  File "crs-config.json", line 1, characters 0-0:
+  Error: Invalid config.
+  In: 42
+  list_of_yojson: list needed
+  [123]
+
+Test deprecated field with GitHub annotation warnings.
+
+  $ cat > crs-config.json <<EOF
+  > { user_mentions_whitelist: [ "user1", "user2" ] }
+  > EOF
+
+  $ crs tools config validate crs-config.json
+  File "crs-config.json", line 1, characters 0-0:
+  Warning: The config field name [user_mentions_whitelist] is deprecated and
+  was renamed [user_mentions_allowlist].
+  Hint: Upgrade the config to use the new name.
+
+  $ crs tools config validate crs-config.json --with-github-annotations-warnings=true
+  File "crs-config.json", line 1, characters 0-0:
+  Warning: The config field name [user_mentions_whitelist] is deprecated and
+  was renamed [user_mentions_allowlist].
+  Hint: Upgrade the config to use the new name.
+  ::warning file=crs-config.json,line=1,col=1,endLine=1,endColumn=1,title=crs::The config field name [user_mentions_whitelist] is deprecated and was renamed%0A[user_mentions_allowlist].%0AHints: Upgrade the config to use the new%0Aname.

--- a/test/cram/validate-config.t
+++ b/test/cram/validate-config.t
@@ -35,8 +35,36 @@ Let's try with valid configs.
   > EOF
 
   $ crs tools config validate crs-config.json
+  File "crs-config.json", line 1, characters 0-0:
+  Warning: The config field name [user_mentions_whitelist] is deprecated and
+  was renamed [user_mentions_allowlist].
+  Hint: Upgrade the config to use the new name.
+  
+  File "crs-config.json", line 1, characters 0-0:
+  Warning: The config field name [invalid_crs_annotation_severity] is now
+  expected to be a json string rather than a list.
+  Hint: Change it to simply: "Warning"
+  
+  File "crs-config.json", line 1, characters 0-0:
+  Warning: The config field name [crs_due_now_annotation_severity] is now
+  expected to be a json string rather than a list.
+  Hint: Change it to simply: "Info"
   $ crs tools config validate crs-config.json --print
-  ((default_repo_owner user1) (user_mentions_whitelist (user1 user2 pr-author))
+  File "crs-config.json", line 1, characters 0-0:
+  Warning: The config field name [user_mentions_whitelist] is deprecated and
+  was renamed [user_mentions_allowlist].
+  Hint: Upgrade the config to use the new name.
+  
+  File "crs-config.json", line 1, characters 0-0:
+  Warning: The config field name [invalid_crs_annotation_severity] is now
+  expected to be a json string rather than a list.
+  Hint: Change it to simply: "Warning"
+  
+  File "crs-config.json", line 1, characters 0-0:
+  Warning: The config field name [crs_due_now_annotation_severity] is now
+  expected to be a json string rather than a list.
+  Hint: Change it to simply: "Info"
+  ((default_repo_owner user1) (user_mentions_allowlist (user1 user2 pr-author))
    (invalid_crs_annotation_severity Warning)
    (crs_due_now_annotation_severity Info))
 
@@ -47,6 +75,10 @@ Fields are usually optional.
   > EOF
 
   $ crs tools config validate crs-config.json --print
+  File "crs-config.json", line 1, characters 0-0:
+  Warning: The config field name [invalid_crs_annotation_severity] is now
+  expected to be a json string rather than a list.
+  Hint: Change it to simply: "Error"
   ((invalid_crs_annotation_severity Error))
 
 Unknown field.
@@ -56,13 +88,10 @@ Unknown field.
   > EOF
 
   $ crs tools config validate crs-config.json >out 2>&1
-  [123]
   $ cat out | sed 's/[a-zA-Z0-9._\/-]*config\.ml/<PATH>\/config.ml/g'
   File "crs-config.json", line 1, characters 0-0:
-  Error: Invalid config.
-  In: {"unknown_field":"Hello"}
-  (Failure
-   "<PATH>/config.ml.t_of_yojson: extra fields: unknown_field")
+  Warning: Unknown config field: [unknown_field]
+  Hint: Check the documentation for valid field names.
 
 Invalid value.
 
@@ -74,7 +103,5 @@ Invalid value.
   [123]
   $ cat out | sed 's/[a-zA-Z0-9._\/-]*config\.ml/<PATH>\/config.ml/g'
   File "crs-config.json", line 1, characters 0-0:
-  Error: Invalid config.
-  In: ["Unknown"]
-  (Failure
-   "<PATH>/config.ml.Annotation_severity.t_of_yojson: unexpected variant constructor")
+  Error: Field [invalid_crs_annotation_severity]:
+  Unsupported annotation severity "Unknown".


### PR DESCRIPTION
Change config loading and format:
    
- Emit warning for deprecated constructs
- Unknown fields are now warnings
- Expect Enums to be json strings
- Rename whitelist -> allowlist
    
Keep existing format backward compatible (with warnings).

Documentation of config format wip & changelog edits left as follow-up work.